### PR TITLE
A Pair of Bug-fixes from NoTimeFix

### DIFF
--- a/src/main/java/hardcorequesting/quests/Quest.java
+++ b/src/main/java/hardcorequesting/quests/Quest.java
@@ -1613,7 +1613,8 @@ public class Quest {
         if (other.completed) {
             own.completed = true;
 
-            if (other.available) {
+            //If a quest is marked both claimed & available, then repeatable quests will never reset.
+            if (other.available && !own.claimed) {
                 own.available = true;
             }
         }


### PR DESCRIPTION
 - Party progress will no longer sometimes reset after a server restart.
 - A new player joining a party will no longer sometimes prevent repeatable quests from coming off cooldown if the quest was marked claimed when a new player who had it marked available joined the party.