### PR TITLE
Made HQM use semantic versioning.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,9 +20,9 @@ apply plugin: 'forge'
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
-version = "The Journey (4.3.0)"
+version = "4.3.0"
 group= "hardcorequesting" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
-archivesBaseName = "HQM"
+archivesBaseName = "HQM-The Journey"
 
 minecraft {
     version = "10.13.4.1448-1.7.10"


### PR DESCRIPTION
By making the version only consist of numbers, future addons will be able to depend on specific versions of the mod (for instance "4.4 or later") and forge will display a nice error screen in case the required version is outdated (instead of having to display one manually after checking for FileVersion). With the way the version was built previously, it was pretty much impossible to retain compatibility as soon as the name ("The Journey") changed. See http://semver.org/ for more details.