### PR TITLE
adds config for sending a message to the client when joining, #33 

### DIFF
--- a/src/main/java/hardcorequesting/PlayerTracker.java
+++ b/src/main/java/hardcorequesting/PlayerTracker.java
@@ -3,6 +3,7 @@ package hardcorequesting;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.PlayerEvent;
+import hardcorequesting.config.ModConfig;
 import hardcorequesting.network.PacketHandler;
 import hardcorequesting.quests.QuestLine;
 import net.minecraft.command.ICommandSender;
@@ -34,7 +35,7 @@ public class PlayerTracker {
 
 		if(QuestingData.isHardcoreActive())
 			sendLoginMessage(player);
-		else
+		else if (ModConfig.NO_HARDCORE_MESSAGE)
 			player.addChatMessage(new ChatComponentText("This server doesn\'t have Hardcore Questing Mode enabled."));
 
         NBTTagCompound tags = player.getEntityData();

--- a/src/main/java/hardcorequesting/config/ModConfig.java
+++ b/src/main/java/hardcorequesting/config/ModConfig.java
@@ -67,6 +67,11 @@ public class ModConfig
     private static final String ROT_COMMENT = "Define in seconds how long the rot timer is.";
     public static int MAXROT;
 
+    public static boolean NO_HARDCORE_MESSAGE;
+    public static final boolean NO_HARDCORE_MESSAGE_DEFAULT = true;
+    public static final String NO_HARDCORE_MESSAGE_COMMENT = "Enable or disable sending a status message if Hardcore Questing mode is off";
+    public static final String NO_HARDCORE_MESSAGE_KEY = "NoHardcoreMessage";
+
     public static int OVERLAY_XPOS;
     public static int OVERLAY_YPOS;
     public static int OVERLAY_XPOSDEFAULT = 2;
@@ -127,6 +132,8 @@ public class ModConfig
 
         ROTTIMER = config.get(CATEGORY_GENERAL, FRESHNESS_KEY, FRESHNESS_DEFAULT, FRESHNESS_COMMENT).getBoolean(FRESHNESS_DEFAULT);
         MAXROT = config.get(CATEGORY_GENERAL, ROT_KEY, ROT_DEFAULT, ROT_COMMENT).getInt(ROT_DEFAULT);
+
+        NO_HARDCORE_MESSAGE = config.get(CATEGORY_GENERAL, NO_HARDCORE_MESSAGE_KEY, NO_HARDCORE_MESSAGE_DEFAULT, NO_HARDCORE_MESSAGE_COMMENT).getBoolean(NO_HARDCORE_MESSAGE_DEFAULT);
 
         if (config.hasChanged())
             config.save();


### PR DESCRIPTION
Setting it to false will not send the 'This server does not have hardcore questing mode enabled.' message to the clients. This is a server side config, disabling it from client side only would require some network code.