### PR TITLE
Scalability-related Performance Enhancements

### DIFF
--- a/src/main/java/hardcorequesting/quests/Quest.java
+++ b/src/main/java/hardcorequesting/quests/Quest.java
@@ -477,7 +477,7 @@ public class Quest {
         return isVisible(QuestingData.getUserName(player));
     }
 
-    public boolean isVisible(EntityPlayer player, Map<Quest, Boolean> isVisibleCache, Map<Quest, Boolean> isLinkFreeCache) {
+    boolean isVisible(EntityPlayer player, Map<Quest, Boolean> isVisibleCache, Map<Quest, Boolean> isLinkFreeCache) {
         return isVisible(QuestingData.getUserName(player), isVisibleCache, isLinkFreeCache);
     }
 
@@ -485,7 +485,7 @@ public class Quest {
         return isVisible(playerName, new HashMap<Quest, Boolean>(), new HashMap<Quest, Boolean>());
     }
 
-    public boolean isVisible(String playerName, Map<Quest, Boolean> isVisibleCache, Map<Quest, Boolean> isLinkFreeCache) {
+    boolean isVisible(String playerName, Map<Quest, Boolean> isVisibleCache, Map<Quest, Boolean> isLinkFreeCache) {
         if (isVisibleCache != null) {
             Boolean cached = isVisibleCache.get(this);
             if (cached != null) {
@@ -505,7 +505,7 @@ public class Quest {
         return isEnabled(QuestingData.getUserName(player));
     }
 
-    public boolean isEnabled(EntityPlayer player, Map<Quest, Boolean> isVisibleCache, Map<Quest, Boolean> isLinkFreeCache) {
+    boolean isEnabled(EntityPlayer player, Map<Quest, Boolean> isVisibleCache, Map<Quest, Boolean> isLinkFreeCache) {
         return isEnabled(QuestingData.getUserName(player), true, isVisibleCache, isLinkFreeCache);
     }
 
@@ -517,7 +517,7 @@ public class Quest {
         return isEnabled(playerName, requiresVisible, new HashMap<Quest, Boolean>(), new HashMap<Quest, Boolean>());
     }
 
-    public boolean isEnabled(String playerName, boolean requiresVisible, Map<Quest, Boolean> isVisibleCache, Map<Quest, Boolean> isLinkFreeCache) {
+    boolean isEnabled(String playerName, boolean requiresVisible, Map<Quest, Boolean> isVisibleCache, Map<Quest, Boolean> isLinkFreeCache) {
         return !(set == null || !isLinkFree(playerName, isLinkFreeCache) || (requiresVisible && !triggerType.doesWorkAsInvisible() && !isVisible(playerName, isVisibleCache, isLinkFreeCache))) && enabledParentEvaluator.isValid(playerName, isVisibleCache, isLinkFreeCache);
     }
 
@@ -525,7 +525,7 @@ public class Quest {
         return isLinkFree(QuestingData.getUserName(player), new HashMap<Quest, Boolean>());
     }
 
-    public boolean isLinkFree(EntityPlayer player, Map<Quest, Boolean> cache) {
+    boolean isLinkFree(EntityPlayer player, Map<Quest, Boolean> cache) {
         return isLinkFree(QuestingData.getUserName(player), cache);
     }
 
@@ -533,12 +533,10 @@ public class Quest {
         return isLinkFree(playerName, new HashMap<Quest, Boolean>());
     }
     
-    public boolean isLinkFree(String playerName, Map<Quest, Boolean> cache) {
-        if (cache != null) {
-            Boolean cached = cache.get(this);
-            if (cached != null) {
-                return cached.booleanValue();
-            }
+    boolean isLinkFree(String playerName, Map<Quest, Boolean> cache) {
+        Boolean cached = cache.get(this);
+        if (cached != null) {
+            return cached.booleanValue();
         }
 
         boolean result = true;
@@ -562,9 +560,7 @@ public class Quest {
             result = linkParentEvaluator.isValid(playerName, null, cache);
         }
 
-        if (cache != null) {
-            cache.put(this, result);
-        }
+        cache.put(this, result);
 
         return result;
     }

--- a/src/main/java/hardcorequesting/quests/Quest.java
+++ b/src/main/java/hardcorequesting/quests/Quest.java
@@ -477,60 +477,116 @@ public class Quest {
         return isVisible(QuestingData.getUserName(player));
     }
 
+    public boolean isVisible(EntityPlayer player, Map<Quest, Boolean> isVisibleCache, Map<Quest, Boolean> isLinkFreeCache) {
+        return isVisible(QuestingData.getUserName(player), isVisibleCache, isLinkFreeCache);
+    }
+
     public boolean isVisible(String playerName) {
-        return triggerType.isQuestVisible(this, playerName) && isLinkFree(playerName) && visibleParentEvaluator.isValid(playerName);
+        return isVisible(playerName, new HashMap<Quest, Boolean>(), new HashMap<Quest, Boolean>());
+    }
+
+    public boolean isVisible(String playerName, Map<Quest, Boolean> isVisibleCache, Map<Quest, Boolean> isLinkFreeCache) {
+        if (isVisibleCache != null) {
+            Boolean cached = isVisibleCache.get(this);
+            if (cached != null) {
+                return cached.booleanValue();
+            }
+        }
+
+        boolean result = triggerType.isQuestVisible(this, playerName) && isLinkFree(playerName, isLinkFreeCache) && visibleParentEvaluator.isValid(playerName, isVisibleCache, isLinkFreeCache);
+        if (isVisibleCache != null) {
+            isVisibleCache.put(this, result);
+        }
+
+        return result;
     }
 
     public boolean isEnabled(EntityPlayer player) {
         return isEnabled(QuestingData.getUserName(player));
     }
 
+    public boolean isEnabled(EntityPlayer player, Map<Quest, Boolean> isVisibleCache, Map<Quest, Boolean> isLinkFreeCache) {
+        return isEnabled(QuestingData.getUserName(player), true, isVisibleCache, isLinkFreeCache);
+    }
+
     public boolean isEnabled(String playerName) {
         return isEnabled(playerName, true);
     }
 
+    public boolean isEnabled(String playerName, boolean requiresVisible) {
+        return isEnabled(playerName, requiresVisible, new HashMap<Quest, Boolean>(), new HashMap<Quest, Boolean>());
+    }
+
+    public boolean isEnabled(String playerName, boolean requiresVisible, Map<Quest, Boolean> isVisibleCache, Map<Quest, Boolean> isLinkFreeCache) {
+        return !(set == null || !isLinkFree(playerName, isLinkFreeCache) || (requiresVisible && !triggerType.doesWorkAsInvisible() && !isVisible(playerName, isVisibleCache, isLinkFreeCache))) && enabledParentEvaluator.isValid(playerName, isVisibleCache, isLinkFreeCache);
+    }
+
     public boolean isLinkFree(EntityPlayer player) {
-        return isLinkFree(QuestingData.getUserName(player));
+        return isLinkFree(QuestingData.getUserName(player), new HashMap<Quest, Boolean>());
+    }
+
+    public boolean isLinkFree(EntityPlayer player, Map<Quest, Boolean> cache) {
+        return isLinkFree(QuestingData.getUserName(player), cache);
     }
 
     public boolean isLinkFree(String playerName) {
+        return isLinkFree(playerName, new HashMap<Quest, Boolean>());
+    }
+    
+    public boolean isLinkFree(String playerName, Map<Quest, Boolean> cache) {
+        if (cache != null) {
+            Boolean cached = cache.get(this);
+            if (cached != null) {
+                return cached.booleanValue();
+            }
+        }
+
+        boolean result = true;
         for (Quest optionLink : optionLinks) {
             if (optionLink.isCompleted(playerName)) {
-                return false;
+                result = false;
+                break;
             }
         }
 
-        for (Quest optionLink : reversedOptionLinks) {
-            if (optionLink.isCompleted(playerName)) {
-                return false;
+        if (result) {
+            for (Quest optionLink : reversedOptionLinks) {
+                if (optionLink.isCompleted(playerName)) {
+                    result = false;
+                    break;
+                }
             }
         }
 
-        return linkParentEvaluator.isValid(playerName);
-    }
+        if (result) {
+            result = linkParentEvaluator.isValid(playerName, null, cache);
+        }
 
-    public boolean isEnabled(String playerName, boolean requiresVisible) {
-        return !(set == null || !isLinkFree(playerName) || (requiresVisible && !triggerType.doesWorkAsInvisible() && !isVisible(playerName))) && enabledParentEvaluator.isValid(playerName);
+        if (cache != null) {
+            cache.put(this, result);
+        }
+
+        return result;
     }
 
     private ParentEvaluator enabledParentEvaluator = new ParentEvaluator() {
         @Override
-        protected boolean isValid(String playerName, Quest parent) {
+        protected boolean isValid(String playerName, Quest parent, Map<Quest, Boolean> isVisibleCache, Map<Quest, Boolean> isLinkFreeCache) {
             return parent.isCompleted(playerName);
         }
     };
 
     private ParentEvaluator linkParentEvaluator = new ParentEvaluator() {
         @Override
-        protected boolean isValid(String playerName, Quest parent) {
-            return parent.isLinkFree(playerName);
+        protected boolean isValid(String playerName, Quest parent, Map<Quest, Boolean> isVisibleCache, Map<Quest, Boolean> isLinkFreeCache) {
+            return parent.isLinkFree(playerName, isLinkFreeCache);
         }
     };
 
     private ParentEvaluator visibleParentEvaluator = new ParentEvaluator() {
         @Override
-        protected boolean isValid(String playerName, Quest parent) {
-            return parent.isVisible(playerName) || parent.isCompleted(playerName);
+        protected boolean isValid(String playerName, Quest parent, Map<Quest, Boolean> isVisibleCache, Map<Quest, Boolean> isLinkFreeCache) {
+            return parent.isVisible(playerName, isVisibleCache, isLinkFreeCache) || parent.isCompleted(playerName);
         }
     };
 
@@ -543,9 +599,9 @@ public class Quest {
     }
 
     private abstract class ParentEvaluator {
-        protected abstract boolean isValid(String playerName, Quest parent);
+        protected abstract boolean isValid(String playerName, Quest parent, Map<Quest, Boolean> isVisibleCache, Map<Quest, Boolean> isLinkFreeCache);
 
-        private boolean isValid(String playerName) {
+        private boolean isValid(String playerName, Map<Quest, Boolean> isVisibleCache, Map<Quest, Boolean> isLinkFreeCache) {
             int parents = getRequirement().size();
             int requiredAmount = useModifiedParentRequirement ? parentRequirementCount : parents;
             if (requiredAmount > parents) {
@@ -555,7 +611,7 @@ public class Quest {
             int allowedUncompleted = parents - requiredAmount;
             int uncompleted = 0;
             for (Quest quest : getRequirement()) {
-                if (!isValid(playerName, quest)) {
+                if (!isValid(playerName, quest, isVisibleCache, isLinkFreeCache)) {
                     uncompleted++;
                     if (uncompleted > allowedUncompleted) {
                         return false;

--- a/src/main/java/hardcorequesting/quests/Quest.java
+++ b/src/main/java/hardcorequesting/quests/Quest.java
@@ -486,17 +486,14 @@ public class Quest {
     }
 
     boolean isVisible(String playerName, Map<Quest, Boolean> isVisibleCache, Map<Quest, Boolean> isLinkFreeCache) {
-        if (isVisibleCache != null) {
-            Boolean cached = isVisibleCache.get(this);
-            if (cached != null) {
-                return cached.booleanValue();
-            }
+        Boolean cachedResult = isVisibleCache.get(this);
+        if (cachedResult != null) {
+            return cachedResult.booleanValue();
         }
 
         boolean result = triggerType.isQuestVisible(this, playerName) && isLinkFree(playerName, isLinkFreeCache) && visibleParentEvaluator.isValid(playerName, isVisibleCache, isLinkFreeCache);
-        if (isVisibleCache != null) {
-            isVisibleCache.put(this, result);
-        }
+
+        isVisibleCache.put(this, result);
 
         return result;
     }

--- a/src/main/java/hardcorequesting/quests/Quest.java
+++ b/src/main/java/hardcorequesting/quests/Quest.java
@@ -531,9 +531,9 @@ public class Quest {
     }
     
     boolean isLinkFree(String playerName, Map<Quest, Boolean> cache) {
-        Boolean cached = cache.get(this);
-        if (cached != null) {
-            return cached.booleanValue();
+        Boolean cachedResult = cache.get(this);
+        if (cachedResult != null) {
+            return cachedResult.booleanValue();
         }
 
         boolean result = true;

--- a/src/main/java/hardcorequesting/quests/QuestSet.java
+++ b/src/main/java/hardcorequesting/quests/QuestSet.java
@@ -14,7 +14,10 @@ import org.lwjgl.input.Keyboard;
 import org.lwjgl.opengl.GL11;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 
 public class QuestSet {
     private String name;
@@ -69,10 +72,14 @@ public class QuestSet {
     }
 
     public boolean isEnabled(EntityPlayer player) {
+        return isEnabled(player, new HashMap<Quest, Boolean>(), new HashMap<Quest, Boolean>());
+    }
+
+    private boolean isEnabled(EntityPlayer player, Map<Quest, Boolean> isVisibleCache, Map<Quest, Boolean> isLinkFreeCache) {
         if (quests.isEmpty()) return false;
 
         for (Quest quest : quests) {
-            if (quest.isEnabled(player)) {
+            if (quest.isEnabled(player, isVisibleCache, isLinkFreeCache)) {
                 return true;
             }
         }
@@ -109,9 +116,13 @@ public class QuestSet {
     }
 
     public int getCompletedCount(EntityPlayer player) {
+        return getCompletedCount(player, new HashMap<Quest, Boolean>(), new HashMap<Quest, Boolean>());
+    }
+
+    private int getCompletedCount(EntityPlayer player, Map<Quest, Boolean> isVisibleCache, Map<Quest, Boolean> isLinkFreeCache) {
         int count = 0;
         for (Quest quest : quests) {
-            if (quest.isCompleted(player) && quest.isEnabled(player)) {
+            if (quest.isCompleted(player) && quest.isEnabled(player, isVisibleCache, isLinkFreeCache)) {
                 count++;
             }
         }
@@ -152,19 +163,22 @@ public class QuestSet {
         EntityPlayer player = gui.getPlayer();
         List<QuestSet> questSets = Quest.getQuestSets();
         int start = setScroll.isVisible(gui) ? Math.round((Quest.getQuestSets().size() - GuiQuestBook.VISIBLE_SETS) * setScroll.getScroll()) : 0;
+
+        HashMap<Quest, Boolean> isVisibleCache = new HashMap<Quest, Boolean>();
+        HashMap<Quest, Boolean> isLinkFreeCache = new HashMap<Quest, Boolean>();
         for (int i = start; i < Math.min(start + GuiQuestBook.VISIBLE_SETS, questSets.size()); i++) {
             QuestSet questSet = questSets.get(i);
 
             int setY = GuiQuestBook.LIST_Y + (i - start) * (GuiQuestBook.TEXT_HEIGHT + GuiQuestBook.TEXT_SPACING);
 
             int total = questSet.getQuests().size();
-            boolean enabled = questSet.isEnabled(player);
-            int completedCount = enabled ? questSet.getCompletedCount(player) : 0; //no need to check for the completed count if it's not enabled
+            boolean enabled = questSet.isEnabled(player, isVisibleCache, isLinkFreeCache);
+            int completedCount = enabled ? questSet.getCompletedCount(player, isVisibleCache, isLinkFreeCache) : 0; //no need to check for the completed count if it's not enabled
 
             boolean completed = true;
             int unclaimed = 0;
             for (Quest quest : questSet.getQuests()) {
-                if (completed && !quest.isCompleted(player) && quest.isLinkFree(player)) {
+                if (completed && !quest.isCompleted(player) && quest.isLinkFree(player, isLinkFreeCache)) {
                     completed = false;
                 }
                 if (quest.isCompleted(player) && quest.hasReward(player)) unclaimed++;
@@ -199,7 +213,7 @@ public class QuestSet {
                 gui.drawString(GuiQuestBook.selectedSet.getDescription(gui), startLine, GuiQuestBook.VISIBLE_DESCRIPTION_LINES, GuiQuestBook.DESCRIPTION_X, GuiQuestBook.DESCRIPTION_Y, 0.7F, 0x404040);
             }
 
-            drawQuestInfo(gui, GuiQuestBook.selectedSet, GuiQuestBook.DESCRIPTION_X, GuiQuestBook.selectedSet == null ? GuiQuestBook.DESCRIPTION_Y : INFO_Y);
+            drawQuestInfo(gui, GuiQuestBook.selectedSet, GuiQuestBook.DESCRIPTION_X, GuiQuestBook.selectedSet == null ? GuiQuestBook.DESCRIPTION_Y : INFO_Y, isVisibleCache, isLinkFreeCache);
         }
 
     }
@@ -218,12 +232,22 @@ public class QuestSet {
             bar.draw(gui, x, y, player);
         }
 
+        HashMap<Quest, Boolean> isVisibleCache = new HashMap<Quest, Boolean>();
+        HashMap<Quest, Boolean> isLinkFreeCache = new HashMap<Quest, Boolean>();
+
+        HashSet<Quest> visibleQuests = new HashSet<Quest>();
+        for (Quest quest : getQuests()) {
+            if (quest.isVisible(player, isVisibleCache, isLinkFreeCache)) {
+                visibleQuests.add(quest);
+            }
+        }
+
         for (Quest child : getQuests()) {
-            if ((Quest.isEditing || child.isVisible(player))) {
+            if (Quest.isEditing || visibleQuests.contains(child)) {
                 for (Quest parent : child.getRequirement()) {
-                    if ((Quest.isEditing || parent.isVisible(player))) {
+                    if (Quest.isEditing || visibleQuests.contains(parent)) {
                         if (parent.hasSameSetAs(child)) {
-                            int color = Quest.isEditing && (!child.isVisible(player) || !parent.isVisible(player)) ? 0x55404040 : 0xFF404040;
+                            int color = Quest.isEditing && (!visibleQuests.contains(child) || !visibleQuests.contains(parent)) ? 0x55404040 : 0xFF404040;
                             gui.drawLine(gui.getLeft() + parent.getGuiCenterX(), gui.getTop() + parent.getGuiCenterY(),
                                     gui.getLeft() + child.getGuiCenterX(), gui.getTop() + child.getGuiCenterY(),
                                     5,
@@ -237,7 +261,7 @@ public class QuestSet {
             for (Quest child : getQuests()) {
                 for (Quest parent : child.getOptionLinks()) {
                     if (parent.hasSameSetAs(child)) {
-                        int color = !child.isVisible(player) || !parent.isVisible(player) ? 0x554040DD : 0xFF4040DD;
+                        int color = !visibleQuests.contains(child) || !visibleQuests.contains(parent) ? 0x554040DD : 0xFF4040DD;
                         gui.drawLine(gui.getLeft() + parent.getGuiCenterX(), gui.getTop() + parent.getGuiCenterY(),
                                 gui.getLeft() + child.getGuiCenterX(), gui.getTop() + child.getGuiCenterY(),
                                 5,
@@ -248,7 +272,7 @@ public class QuestSet {
         }
 
         for (Quest quest : getQuests()) {
-            if ((Quest.isEditing || quest.isVisible(player))) {
+            if ((Quest.isEditing || visibleQuests.contains(quest))) {
 
                 GL11.glPushMatrix();
                 GL11.glEnable(GL11.GL_BLEND);
@@ -275,9 +299,9 @@ public class QuestSet {
 
         for (Quest quest : getQuests()) {
             boolean editing = Quest.isEditing && !GuiScreen.isCtrlKeyDown();
-            if ((editing || quest.isVisible(player)) && quest.isMouseInObject(x, y)) {
+            if ((editing || visibleQuests.contains(quest)) && quest.isMouseInObject(x, y)) {
                 boolean shouldDrawText = false;
-                boolean enabled = quest.isEnabled(player);
+                boolean enabled = quest.isEnabled(player, isVisibleCache, isLinkFreeCache);
                 String txt = "";
 
                 if (enabled || editing) {
@@ -408,12 +432,12 @@ public class QuestSet {
                             txt += "\n" + triggerMessage;
                         }
 
-                        if (!quest.isVisible(player)) {
+                        if (!visibleQuests.contains(quest)) {
                             String invisibilityMessage;
-                            if (quest.isLinkFree(player)) {
+                            if (quest.isLinkFree(player, isLinkFreeCache)) {
                                 boolean parentInvisible = false;
                                 for (Quest parent : quest.getRequirement()) {
-                                    if (!parent.isVisible(player)) {
+                                    if (!visibleQuests.contains(parent)) {
                                         parentInvisible = true;
                                         break;
                                     }
@@ -534,6 +558,11 @@ public class QuestSet {
 
     @SideOnly(Side.CLIENT)
     public static void drawQuestInfo(GuiQuestBook gui, QuestSet set, int x, int y) {
+        drawQuestInfo(gui, set, x, y, new HashMap<Quest, Boolean>(), new HashMap<Quest, Boolean>());
+    }
+
+    @SideOnly(Side.CLIENT)
+    private static void drawQuestInfo(GuiQuestBook gui, QuestSet set, int x, int y, HashMap<Quest, Boolean> isVisibleCache, HashMap<Quest, Boolean> isLinkFreeCache) {
         int completed = 0;
         int reward = 0;
         int enabled = 0;
@@ -545,9 +574,9 @@ public class QuestSet {
         for (Quest quest : Quest.getQuests()) {
             if (set == null || quest.hasSet(set)) {
                 realTotal++;
-                if (quest.isVisible(player)) {
+                if (quest.isVisible(player, isVisibleCache, isLinkFreeCache)) {
                     total++;
-                    if (quest.isEnabled(player)) {
+                    if (quest.isEnabled(player, isVisibleCache, isLinkFreeCache)) {
                         enabled++;
                         if (quest.isCompleted(player)) {
                             completed++;
@@ -578,6 +607,10 @@ public class QuestSet {
     {
         List<QuestSet> questSets = Quest.getQuestSets();
         int start = setScroll.isVisible(gui) ? Math.round((Quest.getQuestSets().size() - GuiQuestBook.VISIBLE_SETS) * setScroll.getScroll()) : 0;
+        
+        HashMap<Quest, Boolean> isVisibleCache = new HashMap<Quest, Boolean>();
+        HashMap<Quest, Boolean> isLinkFreeCache = new HashMap<Quest, Boolean>();
+        
         for (int i = start; i < Math.min(start + GuiQuestBook.VISIBLE_SETS, questSets.size()); i++) {
             QuestSet questSet = questSets.get(i);
 
@@ -601,7 +634,7 @@ public class QuestSet {
                         gui.setEditMenu(new GuiEditMenuTextEditor(gui, gui.getPlayer(),  questSet, true));
                         break;
                     default:
-                        if (!(!Quest.isEditing && questSet.isEnabled(gui.getPlayer())))
+                        if (!(!Quest.isEditing && questSet.isEnabled(gui.getPlayer(), isVisibleCache, isLinkFreeCache)))
                             break;
                     case NORMAL:
                         GuiQuestBook.selectedSet = (GuiQuestBook.selectedSet == questSet ? null : questSet);
@@ -645,8 +678,10 @@ public class QuestSet {
                     break;
             }
         } else {
+            HashMap<Quest, Boolean> isVisibleCache = new HashMap<Quest, Boolean>();
+            HashMap<Quest, Boolean> isLinkFreeCache = new HashMap<Quest, Boolean>();
             for (Quest quest : this.getQuests()) {
-                if ((Quest.isEditing || quest.isVisible(player)) && quest.isMouseInObject(x, y)) {
+                if ((Quest.isEditing || quest.isVisible(player, isVisibleCache, isLinkFreeCache)) && quest.isMouseInObject(x, y)) {
                     if (Quest.isEditing && gui.getCurrentMode() != GuiQuestBook.EditMode.NORMAL) {
                         switch (gui.getCurrentMode()) {
                             case MOVE:

--- a/src/main/java/hardcorequesting/quests/QuestSet.java
+++ b/src/main/java/hardcorequesting/quests/QuestSet.java
@@ -235,19 +235,12 @@ public class QuestSet {
         HashMap<Quest, Boolean> isVisibleCache = new HashMap<Quest, Boolean>();
         HashMap<Quest, Boolean> isLinkFreeCache = new HashMap<Quest, Boolean>();
 
-        HashSet<Quest> visibleQuests = new HashSet<Quest>();
-        for (Quest quest : getQuests()) {
-            if (quest.isVisible(player, isVisibleCache, isLinkFreeCache)) {
-                visibleQuests.add(quest);
-            }
-        }
-
         for (Quest child : getQuests()) {
-            if (Quest.isEditing || visibleQuests.contains(child)) {
+            if (Quest.isEditing || child.isVisible(player, isVisibleCache, isLinkFreeCache)) {
                 for (Quest parent : child.getRequirement()) {
-                    if (Quest.isEditing || visibleQuests.contains(parent)) {
+                    if (Quest.isEditing || parent.isVisible(player, isVisibleCache, isLinkFreeCache)) {
                         if (parent.hasSameSetAs(child)) {
-                            int color = Quest.isEditing && (!visibleQuests.contains(child) || !visibleQuests.contains(parent)) ? 0x55404040 : 0xFF404040;
+                            int color = Quest.isEditing && (!child.isVisible(player, isVisibleCache, isLinkFreeCache) || !parent.isVisible(player, isVisibleCache, isLinkFreeCache)) ? 0x55404040 : 0xFF404040;
                             gui.drawLine(gui.getLeft() + parent.getGuiCenterX(), gui.getTop() + parent.getGuiCenterY(),
                                     gui.getLeft() + child.getGuiCenterX(), gui.getTop() + child.getGuiCenterY(),
                                     5,
@@ -261,7 +254,7 @@ public class QuestSet {
             for (Quest child : getQuests()) {
                 for (Quest parent : child.getOptionLinks()) {
                     if (parent.hasSameSetAs(child)) {
-                        int color = !visibleQuests.contains(child) || !visibleQuests.contains(parent) ? 0x554040DD : 0xFF4040DD;
+                        int color = !child.isVisible(player, isVisibleCache, isLinkFreeCache) || !parent.isVisible(player, isVisibleCache, isLinkFreeCache) ? 0x554040DD : 0xFF4040DD;
                         gui.drawLine(gui.getLeft() + parent.getGuiCenterX(), gui.getTop() + parent.getGuiCenterY(),
                                 gui.getLeft() + child.getGuiCenterX(), gui.getTop() + child.getGuiCenterY(),
                                 5,
@@ -272,7 +265,7 @@ public class QuestSet {
         }
 
         for (Quest quest : getQuests()) {
-            if ((Quest.isEditing || visibleQuests.contains(quest))) {
+            if ((Quest.isEditing || quest.isVisible(player, isVisibleCache, isLinkFreeCache))) {
 
                 GL11.glPushMatrix();
                 GL11.glEnable(GL11.GL_BLEND);
@@ -299,7 +292,7 @@ public class QuestSet {
 
         for (Quest quest : getQuests()) {
             boolean editing = Quest.isEditing && !GuiScreen.isCtrlKeyDown();
-            if ((editing || visibleQuests.contains(quest)) && quest.isMouseInObject(x, y)) {
+            if ((editing || quest.isVisible(player, isVisibleCache, isLinkFreeCache)) && quest.isMouseInObject(x, y)) {
                 boolean shouldDrawText = false;
                 boolean enabled = quest.isEnabled(player, isVisibleCache, isLinkFreeCache);
                 String txt = "";
@@ -432,12 +425,12 @@ public class QuestSet {
                             txt += "\n" + triggerMessage;
                         }
 
-                        if (!visibleQuests.contains(quest)) {
+                        if (!quest.isVisible(player, isVisibleCache, isLinkFreeCache)) {
                             String invisibilityMessage;
                             if (quest.isLinkFree(player, isLinkFreeCache)) {
                                 boolean parentInvisible = false;
                                 for (Quest parent : quest.getRequirement()) {
-                                    if (!visibleQuests.contains(parent)) {
+                                    if (!parent.isVisible(player, isVisibleCache, isLinkFreeCache)) {
                                         parentInvisible = true;
                                         break;
                                     }


### PR DESCRIPTION
Very deep quest graphs can cause massive performance problems.  Firing up WarmRoast, the problem seems to be in the recursively implemented methods "isVisible" and "isLinkFree", which are also called from "isEnabled".  Not only are these methods called multiple times for each drawing run, but they are also called for every single quest... and in very deep graphs, each method itself tends to call itself for a significant portion of the parent quests.

A more proper redesign, in my opinion, would probably be to have separate GUI objects that listen to "changed" events that the quests raise when something actually changes instead of recomputing all this information on-the-fly.  I don't think that's likely to happen.

So instead, this PR does a more surgical fix: in each drawing run, we create a couple of HashMap&lt;Quest, Boolean&gt; objects that remember the result from each "isVisible" or "isLinkFree" call within an operation.