### PR TITLE
 	Turned ItemPrecision into an abstract class, allowing other mods to add their own precision types.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ libs
 *.ipr
 *.iws
 /bin/
+.idea

--- a/src/main/java/hardcorequesting/FileVersion.java
+++ b/src/main/java/hardcorequesting/FileVersion.java
@@ -23,7 +23,8 @@ public enum FileVersion {
     PARENT_COUNT,
     REPUTATION,
     REPUTATION_KILL,
-    REPUTATION_BARS;
+    REPUTATION_BARS,
+    CUSTOM_PRECISION_TYPES;
 
     public boolean contains(FileVersion other) {
         return ordinal() >= other.ordinal();

--- a/src/main/java/hardcorequesting/client/interfaces/GuiEditMenuItem.java
+++ b/src/main/java/hardcorequesting/client/interfaces/GuiEditMenuItem.java
@@ -1,5 +1,6 @@
 package hardcorequesting.client.interfaces;
 
+
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import hardcorequesting.SaveHelper;
 import hardcorequesting.items.ModItems;
@@ -18,6 +19,8 @@ import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 import org.lwjgl.opengl.GL11;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.*;
 import java.util.regex.Pattern;
 
@@ -369,10 +372,12 @@ public class GuiEditMenuItem extends GuiEditMenu {
 
         if (usePrecision()) {
             if (inArrowBounds(gui, mX, mY, true)) {
-                precision = ItemPrecision.values()[(precision.ordinal() + ItemPrecision.values().length - 1) % ItemPrecision.values().length];
+                List<ItemPrecision> precisionTypes = ItemPrecision.getPrecisionTypes();
+                precision = precisionTypes.get((precisionTypes.indexOf(precision) + precisionTypes.size() - 1) % precisionTypes.size());
                 clicked = true;
             }else if (inArrowBounds(gui, mX, mY, false)) {
-                precision = ItemPrecision.values()[(precision.ordinal() + 1) % ItemPrecision.values().length];
+                List<ItemPrecision> precisionTypes = ItemPrecision.getPrecisionTypes();
+                precision = precisionTypes.get((precisionTypes.indexOf(precision) + 1) % precisionTypes.size());
                 clicked = true;
             }
         }

--- a/src/main/java/hardcorequesting/network/DataBitHelper.java
+++ b/src/main/java/hardcorequesting/network/DataBitHelper.java
@@ -43,7 +43,11 @@ public enum DataBitHelper {
     TASK_ITEM_COUNT(6, 35),
     TASK_REQUIREMENT(32),
     QUEST_REWARD(3),
-    ITEM_PRECISION(2),
+    ITEM_PRECISION(30) {
+        public int getBitCount(FileVersion version) {
+            return version.lacks(FileVersion.CUSTOM_PRECISION_TYPES) ? 2 : super.getBitCount(version);
+        }
+    },
     GROUP_ITEMS(6),
     GROUP_COUNT(10),
     TIER_COUNT(7),

--- a/src/main/java/hardcorequesting/parsing/QuestAdapter.java
+++ b/src/main/java/hardcorequesting/parsing/QuestAdapter.java
@@ -58,7 +58,7 @@ public class QuestAdapter {
             if (required != 1)
                 out.name(REQUIRED).value(required);
             if (precision != ItemPrecision.PRECISE)
-                out.name(PRECISION).value(precision.name());
+                out.name(PRECISION).value(ItemPrecision.getUniqueID(precision));
             out.endObject();
         }
 
@@ -78,7 +78,7 @@ public class QuestAdapter {
                 } else if (next.equalsIgnoreCase(REQUIRED)) {
                     required = Math.max(in.nextInt(), required);
                 } else if (next.equalsIgnoreCase(PRECISION)) {
-                    ItemPrecision itemPrecision = ItemPrecision.valueOf(in.nextString());
+                    ItemPrecision itemPrecision = ItemPrecision.getPrecisionType(in.nextString());
                     if (itemPrecision != null) {
                         precision = itemPrecision;
                     }

--- a/src/main/java/hardcorequesting/quests/ItemPrecision.java
+++ b/src/main/java/hardcorequesting/quests/ItemPrecision.java
@@ -1,53 +1,151 @@
 package hardcorequesting.quests;
 
+import com.google.common.collect.ImmutableList;
 import hardcorequesting.OreDictionaryHelper;
 import hardcorequesting.Translator;
 import net.minecraft.item.ItemStack;
 
-public enum ItemPrecision {
-    PRECISE("precise") {
-        @Override
-        protected boolean same(ItemStack item1, ItemStack item2) {
-            return item1.getItem() == item2.getItem() && item1.getItemDamage() == item2.getItemDamage() && ItemStack.areItemStackTagsEqual(item1, item2);
-        }
-    },
-    NBT_FUZZY("nbtFuzzy") {
-        @Override
-        protected boolean same(ItemStack item1, ItemStack item2) {
-            return item1.getItem() == item2.getItem() && item1.getItemDamage() == item2.getItemDamage();
-        }
-    },
-    FUZZY("fuzzy") {
-        @Override
-        protected boolean same(ItemStack item1, ItemStack item2) {
-            return item1.getItem() == item2.getItem();
-        }
-    },
-    ORE_DICTIONARY("oreDict") {
-        @Override
-        protected boolean same(ItemStack item1, ItemStack item2)
-        {
-            return OreDictionaryHelper.match(item1, item2) || PRECISE.same(item1, item2);
-        }
-    };
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
-    private String id;
-    private ItemPrecision(String name) {
-        this.id = name;
-    }
+public abstract class ItemPrecision {
+	public static final ItemPrecision PRECISE = new ItemPrecision("precise") {
+		@Override
+		protected boolean same(ItemStack item1, ItemStack item2) {
+			return item1.getItem() == item2.getItem() && item1.getItemDamage() == item2.getItemDamage() && ItemStack.areItemStackTagsEqual(item1, item2);
+		}
+	};
+	public static final ItemPrecision NBT_FUZZY = new ItemPrecision("nbtFuzzy") {
+		@Override
+		protected boolean same(ItemStack item1, ItemStack item2) {
+			return item1.getItem() == item2.getItem() && item1.getItemDamage() == item2.getItemDamage();
+		}
+	};
+	public static final ItemPrecision FUZZY = new ItemPrecision("fuzzy", true) {
+		@Override
+		protected boolean same(ItemStack item1, ItemStack item2) {
+			return item1.getItem() == item2.getItem();
+		}
 
-    protected abstract boolean same(ItemStack item1, ItemStack item2);
-    public final boolean areItemsSame(ItemStack item1, ItemStack item2) {
-        return item1 == null && item2 == null || item1 != null && item2 != null && same(item1, item2);
-    }
+		@Override
+		public ItemStack[] getPermutations(ItemStack stack) {
+			List<ItemStack> items = new ArrayList<>();
+			stack.getItem().getSubItems(stack.getItem(), null, items);
+			return items.toArray(new ItemStack[items.size()]);
+		}
+	};
+	public static final ItemPrecision ORE_DICTIONARY = new ItemPrecision("oreDict", true) {
+		@Override
+		protected boolean same(ItemStack item1, ItemStack item2) {
+			return OreDictionaryHelper.match(item1, item2) || PRECISE.same(item1, item2);
+		}
 
-    public String getName()
-    {
-        return Translator.translate("hqm.precision." + id);
-    }
+		@Override
+		public ItemStack[] getPermutations(ItemStack stack) {
+			return OreDictionaryHelper.getPermutations(stack);
+		}
+	};
 
-    @Override
-    public String toString() {
-        return id;
-    }
+	private String tag;
+
+	public ItemPrecision(String tag) {
+		this.tag = tag;
+	}
+
+	public ItemPrecision(String tag, boolean hasPermutations) {
+		this(tag);
+		this.hasPermutations = hasPermutations;
+	}
+
+	protected abstract boolean same(ItemStack item1, ItemStack item2);
+
+	public final boolean areItemsSame(ItemStack item1, ItemStack item2) {
+		return item1 == null && item2 == null || item1 != null && item2 != null && same(item1, item2);
+	}
+
+	@Override
+	public String toString() {
+		return tag;
+	}
+
+	public String getLocalizationTag(){
+		return "hqm.precision." + tag;
+	}
+
+	public String getName() {
+		return Translator.translate(getLocalizationTag());
+	}
+
+	protected boolean hasPermutations = false;
+
+	public boolean hasPermutations() {
+		return hasPermutations;
+	}
+
+	public ItemStack[] getPermutations(ItemStack stack) {
+		return new ItemStack[0];
+	}
+
+	// Registry things
+
+	private static final LinkedHashMap<String, ItemPrecision> precisionTypes;
+
+	static {
+		// Need to do this here to avoid NPE
+		precisionTypes = new LinkedHashMap<>();
+		// Using the former names of the enum entries for backwards compatibility
+		registerPrecisionType("PRECISE", PRECISE);
+		registerPrecisionType("NBT_FUZZY", NBT_FUZZY);
+		registerPrecisionType("FUZZY", FUZZY);
+		registerPrecisionType("ORE_DICTIONARY", ORE_DICTIONARY);
+	}
+
+	public static boolean registerPrecisionType(String uniqueID, ItemPrecision p) {
+		if(uniqueID == null || p == null) {
+			return false;
+		}
+		if(!precisionTypes.containsKey(uniqueID)) {
+			precisionTypes.put(uniqueID, p);
+			return true;
+		}
+		return false;
+	}
+
+	public static ImmutableList<ItemPrecision> getPrecisionTypes() {
+		return ImmutableList.copyOf(precisionTypes.values());
+	}
+
+	public static ItemPrecision getPrecisionType(String uniqueID) {
+		return precisionTypes.containsKey(uniqueID) ? precisionTypes.get(uniqueID) : PRECISE;
+	}
+
+	// For backwards compatibility
+
+	public static ItemPrecision getOldPrecisionType(int ordinal) {
+		switch(ordinal) {
+			case 1: {
+				return NBT_FUZZY;
+			}
+			case 2: {
+				return FUZZY;
+			}
+			case 3: {
+				return ORE_DICTIONARY;
+			}
+			default: {
+				return PRECISE;
+			}
+		}
+	}
+
+	public static String getUniqueID(ItemPrecision p) {
+		for(Map.Entry<String, ItemPrecision> entry : precisionTypes.entrySet()) {
+			if(entry.getValue() == p) {
+				return entry.getKey();
+			}
+		}
+		return "PRECISE";
+	}
 }


### PR DESCRIPTION
This allows addons to [add their own types of item precision](https://github.com/Vexatos/BeeSpecific/blob/master/src/main/java/vexatos/beespecific/precision/SpeciesSpecificPrecisionType.java).

~~For some reason I am unable to squash the commits. Sorry for that. I hope it'll get merged anyway.~~ Thanks, @tterrag1098!

Posting this PR because @LordDusk told me to. It's "tested" as in "I made a bunch of random quests related to this and made an addon depending on this mechanic and it seems to work just fine".

Shouldn't break too much, it appears to save and restore properly.