### PR TITLE
Using reward bag names as titles in GuiReward

### DIFF
--- a/src/main/java/hardcorequesting/client/interfaces/GuiReward.java
+++ b/src/main/java/hardcorequesting/client/interfaces/GuiReward.java
@@ -107,7 +107,15 @@ public class GuiReward extends GuiBase {
         int mX = mX0 - left;
         int mY = mY0 - top;
 
-        drawCenteredString(group.getTier().getColor() + Translator.translate("hqm.rewardGui.tierReward", group.getTier().getName()), 0, 0, 1F, TEXTURE_WIDTH, TITLE_HEIGHT, 0x404040);
+        String title = group.getName();
+
+        // fall back to the tier's name if this particular bag has no title,
+        // or if the user explicitly asked us to do so.
+        if (ModConfig.ALWAYS_USE_TIER_NAME_FOR_REWARD_TITLES || title == null || title.isEmpty()) {
+            title = Translator.translate("hqm.rewardGui.tierReward", group.getTier().getName());
+        }
+
+        drawCenteredString(group.getTier().getColor() + title, 0, 0, 1F, TEXTURE_WIDTH, TITLE_HEIGHT, 0x404040);
         drawCenteredString(statisticsText, 0, TITLE_HEIGHT, 0.7F, TEXTURE_WIDTH, TOP_HEIGHT - TITLE_HEIGHT, 0x707070);
         drawCenteredString(Translator.translate("hqm.rewardGui.close"), 0, TOP_HEIGHT + lines * MIDDLE_HEIGHT, 0.7F, TEXTURE_WIDTH, BOTTOM_HEIGHT, 0x707070);
 

--- a/src/main/java/hardcorequesting/config/ModConfig.java
+++ b/src/main/java/hardcorequesting/config/ModConfig.java
@@ -72,6 +72,11 @@ public class ModConfig
     public static final String NO_HARDCORE_MESSAGE_COMMENT = "Enable or disable sending a status message if Hardcore Questing mode is off";
     public static final String NO_HARDCORE_MESSAGE_KEY = "NoHardcoreMessage";
 
+    public static boolean ALWAYS_USE_TIER_NAME_FOR_REWARD_TITLES;
+    private static final String ALWAYS_USE_TIER_NAME_FOR_REWARD_TITLES_KEY = "AlwaysUseTierNameForRewardTitles";
+    private static final boolean ALWAYS_USE_TIER_NAME_FOR_REWARD_TITLES_DEFAULT = false;
+    private static final String ALWAYS_USE_TIER_NAME_FOR_REWARD_TITLES_COMMENT = "Always display the tier name, instead of the individual bag's name, when opening a reward bag.";
+
     public static int OVERLAY_XPOS;
     public static int OVERLAY_YPOS;
     public static int OVERLAY_XPOSDEFAULT = 2;
@@ -134,6 +139,8 @@ public class ModConfig
         MAXROT = config.get(CATEGORY_GENERAL, ROT_KEY, ROT_DEFAULT, ROT_COMMENT).getInt(ROT_DEFAULT);
 
         NO_HARDCORE_MESSAGE = config.get(CATEGORY_GENERAL, NO_HARDCORE_MESSAGE_KEY, NO_HARDCORE_MESSAGE_DEFAULT, NO_HARDCORE_MESSAGE_COMMENT).getBoolean(NO_HARDCORE_MESSAGE_DEFAULT);
+
+        ALWAYS_USE_TIER_NAME_FOR_REWARD_TITLES = config.get(CATEGORY_GENERAL, ALWAYS_USE_TIER_NAME_FOR_REWARD_TITLES_KEY, ALWAYS_USE_TIER_NAME_FOR_REWARD_TITLES_DEFAULT, ALWAYS_USE_TIER_NAME_FOR_REWARD_TITLES_COMMENT).getBoolean(ALWAYS_USE_TIER_NAME_FOR_REWARD_TITLES_DEFAULT);
 
         if (config.hasChanged())
             config.save();


### PR DESCRIPTION
Reward bags can have names.  However, these names are never displayed to the user.  This can be fairly disappointing to a mod pack creator, because instead of this:
![No. 7 with Lettuce](http://i.imgur.com/lVSqNaI.png)

a user will see something more like this:
![Common Reward](http://i.imgur.com/k8Zxd0f.png)

which makes the narrative basically lost.

This pull request uses the reward bag's name as the GUI's title if present, or the tier's name (current behavior) otherwise.

It also adds a config option that mod pack owners can set to revert to the legacy behavior, in case they have reward bag definitions with names that are meaningless to the user and don't want to have to go through and change all of them.