### PR TITLE
HQM "new worlds will automatically activate Questing mode" Config Fix.

### DIFF
--- a/src/main/java/hardcorequesting/event/EventHandler.java
+++ b/src/main/java/hardcorequesting/event/EventHandler.java
@@ -74,6 +74,13 @@ public class EventHandler {
     }
 
     @SubscribeEvent
+    public void onEvent(PlayerEvent.PlayerLoggedInEvent event) {
+        if(QuestingData.autoQuestActivate) {
+            QuestingData.activateQuest(true);
+        }
+    }
+
+    @SubscribeEvent
     public void onEvent(PlayerEvent.ItemCraftedEvent event) {
         for (QuestTask task : getTasks(Type.CRAFTING)) {
             task.onCrafting(event);


### PR DESCRIPTION
The config option for "new worlds will automatically activate Questing mode" wasn't working, True of false it was always false.

So me and vincentmet made a @subscriberEvent to fix this error.

Now the config is working correctly.

Prior to this fix the only way to get the book to activate questing would be to put your game in cheat mode and do /hqm quest.
