### PR TITLE
Attempt to fix pick up item crash

### DIFF
--- a/src/main/java/hardcorequesting/quests/Quest.java
+++ b/src/main/java/hardcorequesting/quests/Quest.java
@@ -25,6 +25,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.Tuple;
+import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -1277,8 +1278,10 @@ public class Quest {
     }
 
     public void sendUpdatedDataToTeam(Team team) {
-        for (PlayerEntry entry : team.getPlayers()) {
-            sendUpdatedData(entry.getPlayerMP());
+        if (FMLCommonHandler.instance().getSide().isServer()) {
+            for (PlayerEntry entry : team.getPlayers()) {
+                sendUpdatedData(entry.getPlayerMP());
+            }
         }
     }
 


### PR DESCRIPTION
I'm about to fall asleep, so sorry if this is completely off. I'll look again in the morning.

This is an attempt to fix #339 - I ran it and it works after creating a quest that requires oak wood, but I haven't done more than a basic test (Set a quest for oak logs, get oak logs, submit)

Hypothetically it could also call {Server}.isSinglePlayer() but I didn't think of it until I was writing this