### PR TITLE
Fixed bug preventing quests from being saved; reputations had to be c…

### DIFF
--- a/src/main/java/hardcorequesting/commands/CommandSave.java
+++ b/src/main/java/hardcorequesting/commands/CommandSave.java
@@ -46,7 +46,7 @@ public class CommandSave extends CommandBase {
     public void handleCommand(ICommandSender sender, String[] arguments) throws CommandException {
         if (arguments.length == 1 && arguments[0].equals("all")) {
             try {
-                save(sender, Reputation.getReputations(), new TypeToken<List<Reputation>>() {
+                save(sender, Reputation.getReputations().values(), new TypeToken<List<Reputation>>() {
                 }.getType(), "reputations");
                 save(sender, GroupTier.getTiers(), new TypeToken<List<GroupTier>>() {
                 }.getType(), "bags");


### PR DESCRIPTION
…onverted to a Collection to serialize.

Reputations are stored in a Map<> type, which does not extend Collection even if it's in the Collections library. The GSON serializer did not know what to do with it. We can create an intermediate Collection type by calling .values().