### PR TITLE
[1.12] Fixed reward bags leaking in every single creative tabs

### DIFF
--- a/src/main/java/hardcorequesting/items/ItemBag.java
+++ b/src/main/java/hardcorequesting/items/ItemBag.java
@@ -92,7 +92,6 @@ public class ItemBag extends Item {
     }
 
     @Override
-    @SideOnly(Side.CLIENT)
     public void getSubItems(CreativeTabs tabs, NonNullList<ItemStack> stackList) {
         if (isInCreativeTab(tabs)) {
             for (int i = 0; i < BagTier.values().length; i++) {

--- a/src/main/java/hardcorequesting/items/ItemBag.java
+++ b/src/main/java/hardcorequesting/items/ItemBag.java
@@ -94,8 +94,10 @@ public class ItemBag extends Item {
     @Override
     @SideOnly(Side.CLIENT)
     public void getSubItems(CreativeTabs tabs, NonNullList<ItemStack> stackList) {
-        for (int i = 0; i < BagTier.values().length; i++) {
-            stackList.add(new ItemStack(this, 1, i));
+        if (isInCreativeTab(tabs)) {
+            for (int i = 0; i < BagTier.values().length; i++) {
+                stackList.add(new ItemStack(this, 1, i));
+            }
         }
     }
 


### PR DESCRIPTION
So, this is a thing, and happens on 1.12.x only. Since Forge 2360, the `getSubItems` method is no longer client side only for ingredient iteration uses, subitems without a creative tab check would leak in every single creative tabs.
This is a simple fix for the reward bags so they don't leak in every single creative tabs by adding an `isInCreativeTab` check. I've also removed the client side annotation as mentioned above.