### PR TITLE
Resolve #402: removed mods causing crash.

### DIFF
--- a/src/main/java/hardcorequesting/io/adapter/BagAdapter.java
+++ b/src/main/java/hardcorequesting/io/adapter/BagAdapter.java
@@ -56,7 +56,7 @@ public class BagAdapter {
                         in.beginArray();
                         while (in.hasNext()) {
                             ItemStack stack = MinecraftAdapter.ITEM_STACK.read(in);
-                            if (stack != null) {
+                            if (!stack.isEmpty()) {
                                 items.add(stack);
                             }
                         }

--- a/src/main/java/hardcorequesting/io/adapter/MinecraftAdapter.java
+++ b/src/main/java/hardcorequesting/io/adapter/MinecraftAdapter.java
@@ -89,7 +89,7 @@ public class MinecraftAdapter {
 
             Item item = Item.getByNameOrId(id);
             if (item == null) {
-                return null;
+                return ItemStack.EMPTY;
             }
             ItemStack stack = new ItemStack(item, size, damage);
             stack.setTagCompound(tag);

--- a/src/main/java/hardcorequesting/io/adapter/MinecraftAdapter.java
+++ b/src/main/java/hardcorequesting/io/adapter/MinecraftAdapter.java
@@ -67,7 +67,7 @@ public class MinecraftAdapter {
         @Override
         public ItemStack read(JsonReader in) throws IOException {
             if (in.peek() == JsonToken.NULL) {
-                return null;
+                return ItemStack.EMPTY;
             }
             String id = "";
             int damage = 0, size = 1;

--- a/src/main/java/hardcorequesting/io/adapter/QuestAdapter.java
+++ b/src/main/java/hardcorequesting/io/adapter/QuestAdapter.java
@@ -266,7 +266,7 @@ public class QuestAdapter {
             in.beginArray();
             while (in.hasNext()) {
                 ItemStack stack = MinecraftAdapter.ITEM_STACK.read(in);
-                if (stack != null)
+                if (!stack.isEmpty())
                     stacks.add(stack);
             }
             in.endArray();
@@ -308,7 +308,10 @@ public class QuestAdapter {
                         QUEST.setBigIcon(in.nextBoolean());
                         break;
                     case ICON:
-                        QUEST.setIconStack(MinecraftAdapter.ITEM_STACK.read(in));
+                        ItemStack icon = MinecraftAdapter.ITEM_STACK.read(in);
+                        if (!icon.isEmpty()) {
+                            QUEST.setIconStack(icon);
+                        }
                         break;
                     case REQUIREMENTS:
                         readStringArray(requirement, in);

--- a/src/main/java/hardcorequesting/io/adapter/QuestTaskAdapter.java
+++ b/src/main/java/hardcorequesting/io/adapter/QuestTaskAdapter.java
@@ -155,7 +155,10 @@ public class QuestTaskAdapter {
                 } else if (name.equalsIgnoreCase(RADIUS)) {
                     result.setRadius(in.nextInt());
                 } else if (name.equalsIgnoreCase(ICON)) {
-                    result.setIconStack(MinecraftAdapter.ITEM_STACK.read(in));
+                    ItemStack icon = MinecraftAdapter.ITEM_STACK.read(in);
+                    if (!icon.isEmpty()) {
+                        result.setIconStack(icon);
+                    }
                 } else if (name.equalsIgnoreCase(VISIBLE)) {
                     result.setVisible(QuestTaskLocation.Visibility.valueOf(in.nextString()));
                 }
@@ -244,7 +247,10 @@ public class QuestTaskAdapter {
                 if (name.equalsIgnoreCase(NAME)) {
                     result.setName(in.nextString());
                 } else if (name.equalsIgnoreCase(ICON)) {
-                    result.setIconStack(MinecraftAdapter.ITEM_STACK.read(in));
+                    ItemStack icon = MinecraftAdapter.ITEM_STACK.read(in);
+                    if (!icon.isEmpty()) {
+                        result.setIconStack(icon);
+                    }
                 } else if (name.equalsIgnoreCase(MOB)) {
                     result.setMob(in.nextString());
                 } else if (name.equalsIgnoreCase(EXACT)) {


### PR DESCRIPTION
If a mod is removed and an item from it was used as a reward or requirement, stack can actually be null rather than the default Item.EMPTY_ITEM.