### PR TITLE
Fix grey tooltips in reward bag GUI.

### DIFF
--- a/src/main/java/hardcorequesting/client/interfaces/GuiReward.java
+++ b/src/main/java/hardcorequesting/client/interfaces/GuiReward.java
@@ -119,7 +119,7 @@ public class GuiReward extends GuiBase {
             } catch (Throwable ignored) {
             }
         }
-
+        GlStateManager.disableLighting();
         for (Reward reward : rewards) {
             if (inBounds(reward.x, reward.y, ITEM_SIZE, ITEM_SIZE, mX, mY)) {
                 try {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/307683/47491599-df15d500-d7e6-11e8-8335-79d40b0192e7.png)

After:
![image](https://user-images.githubusercontent.com/307683/47491607-e341f280-d7e6-11e8-837b-7601ad7e13c3.png)

Calling `itemRenderer.renderItemOverlayIntoGUI()` re-enables the GL lighting feature, which affects the color. This change disables it after the call.
