### PR TITLE
Fix GlStateManager issue and add edit-mode toggle

### DIFF
--- a/src/main/java/hardcorequesting/client/interfaces/GuiReward.java
+++ b/src/main/java/hardcorequesting/client/interfaces/GuiReward.java
@@ -11,6 +11,7 @@ import hardcorequesting.util.TooltipFlag;
 import hardcorequesting.util.Translator;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;

--- a/src/main/java/hardcorequesting/commands/CommandEditMode.java
+++ b/src/main/java/hardcorequesting/commands/CommandEditMode.java
@@ -1,0 +1,25 @@
+package hardcorequesting.commands;
+
+import hardcorequesting.quests.Quest;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.text.TextComponentTranslation;
+
+public class CommandEditMode extends CommandBase {
+
+    public CommandEditMode() {
+        super("mode");
+    }
+
+    @Override
+    public void handleCommand(ICommandSender sender, String[] arguments) {
+        if (sender instanceof EntityPlayer && isPlayerOp(sender)) {
+            Quest.isEditing = !Quest.isEditing;
+            if (Quest.isEditing) {
+                sender.sendMessage(new TextComponentTranslation(("Editing mode is now enabled.").toString()));
+            } else {
+                sender.sendMessage(new TextComponentTranslation(("Editing mode is now disabled.").toString()));
+            }
+        }
+    }
+}

--- a/src/main/java/hardcorequesting/commands/CommandHandler.java
+++ b/src/main/java/hardcorequesting/commands/CommandHandler.java
@@ -27,6 +27,7 @@ public class CommandHandler extends CommandBase {
         register(new CommandHardcore());
         register(new CommandLives());
         register(new CommandEdit());
+        register(new CommandEditMode());
         register(new CommandEnable());
         register(new CommandSave());
         register(new CommandLoad());


### PR DESCRIPTION
The most recent PR merged appears to have missed the actual import of the GlStateManager meaning the code base would not compile.

Primarily, add an op-only toggle (/hqm mode) that allows switching between edit mode and non-edit mode without restarting.