### PR TITLE
Implement JEI integration: click on item requirements to open JEI.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ repositories {
 
 dependencies {
     deobfCompile "mcp.mobius.waila:Hwyla:${project.hwyla_version}"
+    deobfProvided "mezz.jei:jei_${project.jei_version}:api"
     runtime "mezz.jei:jei_${project.jei_version}"
     deobfCompile "de.ellpeck.actuallyadditions:ActuallyAdditions:${project.actadd_version}"
 }

--- a/src/main/java/hardcorequesting/integration/jei/JEIIntegration.java
+++ b/src/main/java/hardcorequesting/integration/jei/JEIIntegration.java
@@ -1,0 +1,25 @@
+package hardcorequesting.integration.jei;
+
+import net.minecraft.item.ItemStack;
+import mezz.jei.api.*;
+import mezz.jei.api.recipe.IFocus;
+import net.minecraftforge.fml.common.Loader;
+
+@JEIPlugin
+public class JEIIntegration implements IModPlugin {
+    private static IJeiRuntime runtime = null;
+    private static Boolean enabled = null;
+
+
+    @Override
+    public void onRuntimeAvailable(IJeiRuntime jeiRuntime) {
+        runtime = jeiRuntime;
+    }
+
+    public static void showItemStack (ItemStack item) {
+        IRecipeRegistry register = runtime.getRecipeRegistry();
+
+        IFocus<?> focus = register.createFocus(IFocus.Mode.OUTPUT, item);
+        runtime.getRecipesGui().show(focus);
+    }
+}

--- a/src/main/java/hardcorequesting/quests/task/QuestTaskItems.java
+++ b/src/main/java/hardcorequesting/quests/task/QuestTaskItems.java
@@ -4,6 +4,7 @@ import hardcorequesting.client.EditMode;
 import hardcorequesting.client.interfaces.GuiColor;
 import hardcorequesting.client.interfaces.GuiQuestBook;
 import hardcorequesting.client.interfaces.edit.GuiEditMenuItem;
+import hardcorequesting.integration.jei.JEIIntegration;
 import hardcorequesting.quests.ItemPrecision;
 import hardcorequesting.quests.Quest;
 import hardcorequesting.quests.QuestingData;
@@ -17,6 +18,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.NonNullList;
 import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
@@ -263,7 +265,15 @@ public abstract class QuestTaskItems extends QuestTask {
                     break;
                 }
             }
-
+        } else {
+            if (Loader.isModLoaded("jei")) {
+                for (ItemRequirement item : getEditFriendlyItems(this.items)) {
+                    if (gui.inBounds(item.x, item.y, SIZE, SIZE, mX, mY)) {
+                        JEIIntegration.showItemStack(item.getStack());
+                        return;
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Clicking on an item requirement for any quest type will now allow you to
see that item's JEI entry, if one exists for it.

If you do not have JEI installed, nothing will happen!

Tested in an external environment with just Forge and HQM to ensure that there were no issues with lingering JEI code. Likewise added JEI to the pack to ensure that it worked properly. 

Tweaks the build.gradle according to the suggested syntax for JEI in order to have the API to compile against.