### PR TITLE
Don't show tooltips when in MOVE edit mode.

### DIFF
--- a/src/main/java/hardcorequesting/client/interfaces/GuiQuestBook.java
+++ b/src/main/java/hardcorequesting/client/interfaces/GuiQuestBook.java
@@ -531,7 +531,9 @@ public class GuiQuestBook extends GuiBase {
             editMenu.drawMouseOver(this, x, y);
         }
 
-        buttons.forEach(button -> button.drawMouseOver(this, player, x, y));
+        if (currentMode != EditMode.MOVE) {
+            buttons.forEach(button -> button.drawMouseOver(this, player, x, y));
+        }
 
         if (shouldDisplayAndIsInArrowBounds(false, x, y)) {
             drawMouseOver(Translator.translate("hqm.questBook.goBack") + "\n" + GuiColor.GRAY + Translator.translate("hqm.questBook.rightClick"), x + left, y + top);

--- a/src/main/java/hardcorequesting/quests/QuestSet.java
+++ b/src/main/java/hardcorequesting/quests/QuestSet.java
@@ -688,7 +688,7 @@ public class QuestSet {
                     }
                 }
 
-                if (shouldDrawText) {
+                if (shouldDrawText && gui.getCurrentMode() != EditMode.MOVE) {
                     gui.drawMouseOver(txt, x0, y0);
                 }
                 break;


### PR DESCRIPTION
Pretty much does what it says on the tin: when re-positioning quests in move mode, the tooltip can sometimes be quite an obstruction on the screen. This simply prevents the quest tooltip (and all the extra information the edit mode variant contains) from rendering in that circumstance.