### PR TITLE
Specify a username for runClient for better consistency.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,10 @@ buildscript {
 apply plugin: 'net.minecraftforge.gradle.forge'
 apply plugin: 'idea'
 
+runClient {
+    args '--username', 'hqmtest'
+}
+
 repositories {
     maven {
         name = "Forge"


### PR DESCRIPTION
Although this may not work for genIntelliJ runs, but I've always had problems getting those to properly work and instead relied on a Gradle task for runClient.