### PR TITLE
Allow new lines to be placed in entries using \n.

### DIFF
--- a/src/main/java/hardcorequesting/client/interfaces/edit/GuiEditMenuTextEditor.java
+++ b/src/main/java/hardcorequesting/client/interfaces/edit/GuiEditMenuTextEditor.java
@@ -44,6 +44,10 @@ public class GuiEditMenuTextEditor extends GuiEditMenu {
 
     protected GuiEditMenuTextEditor(GuiQuestBook gui, EntityPlayer player, String txt, boolean isName) {
         super(gui, player, false);
+        if (txt != null && !txt.isEmpty()) {
+            txt = txt.replace("\n", "\\n");
+        }
+
         this.text = new TextBoxLogic(gui, txt, 140, true);
         this.isName = isName;
         buttons.add(new LargeButton("hqm.textEditor.copyAll", 185, 20) {
@@ -76,7 +80,11 @@ public class GuiEditMenuTextEditor extends GuiEditMenu {
 
             @Override
             public void onClick(GuiBase gui, EntityPlayer player) {
-                text.addText(gui, GuiScreen.getClipboardString());
+                String clip = GuiScreen.getClipboardString();
+                if (!clip.isEmpty()) {
+                    clip = clip.replace("\n", "\\n");
+                }
+                text.addText(gui, clip);
             }
         });
 
@@ -110,7 +118,11 @@ public class GuiEditMenuTextEditor extends GuiEditMenu {
 
             @Override
             public void onClick(GuiBase gui, EntityPlayer player) {
-                text.setTextAndCursor(gui, GuiScreen.getClipboardString());
+                String clip = GuiScreen.getClipboardString();
+                if (!clip.isEmpty()) {
+                    clip = clip.replace("\n", "\\n");
+                }
+                text.setTextAndCursor(gui, clip);
             }
         });
     }
@@ -194,6 +206,10 @@ public class GuiEditMenuTextEditor extends GuiEditMenu {
         String str = text.getText();
         if (str == null || str.isEmpty()) {
             str = Translator.translate("hqm.textEditor.unnamed");
+        }
+
+        if (!isName && group == null && groupTier == null) {
+            str = str.replace("\\n", "\n");
         }
 
         if (quest != null) {


### PR DESCRIPTION
Line breaks are converted into "\n"s when editing an entry that contains
them, and then they are converted back when saving. Entering "\n"s into
the entry will thus present line breaks.

This is one of the first things I wanted when I started playing around
with HQM, and it's something I've seen a lot of other people ask for.

I don't believe this will cause any issues. I've tested it quite extensively in my local build when compiling quests.