### PR TITLE
Potentially improve a delay check.

### DIFF
--- a/src/main/java/hardcorequesting/quests/task/QuestTaskLocation.java
+++ b/src/main/java/hardcorequesting/quests/task/QuestTaskLocation.java
@@ -47,8 +47,9 @@ public class QuestTaskLocation extends QuestTask {
     private void tick(EntityPlayer player, boolean isPlayerEvent) {
         if (!isPlayerEvent) {
             delay++;
-            delay %= CHECK_DELAY;
-        } else if (this.delay == 0) {
+        } else if (this.delay >= 0) {
+            delay = 0;
+
             World world = player.getEntityWorld();
             if (!world.isRemote) {
                 boolean[] visited = ((QuestDataTaskLocation) this.getData(player)).visited;


### PR DESCRIPTION
I noticed when testing that there were instances where non-player events
were occurring so rapidly that delay never equalled 0, meaning the rest
of the code never actually triggered (tested with breakpoints).