### PR TITLE
Resolve #424, #427: manual detection & Advancement tasks.

### DIFF
--- a/src/main/java/hardcorequesting/client/interfaces/edit/GuiEditMenuAdvancement.java
+++ b/src/main/java/hardcorequesting/client/interfaces/edit/GuiEditMenuAdvancement.java
@@ -1,0 +1,162 @@
+package hardcorequesting.client.interfaces.edit;
+
+import hardcorequesting.client.interfaces.*;
+import hardcorequesting.quests.task.QuestTaskAdvancement;
+import net.minecraft.advancements.Advancement;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.world.WorldServer;
+import net.minecraftforge.common.DimensionManager;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class GuiEditMenuAdvancement extends GuiEditMenuExtended {
+
+    private static final int START_X = 20;
+    private static final int START_Y = 20;
+    private static final int OFFSET_Y = 8;
+    private static final int VISIBLE_MOBS = 24;
+    private QuestTaskAdvancement task;
+    private QuestTaskAdvancement.AdvancementTask advancement;
+    private int id;
+    private ScrollBar scrollBar;
+
+    private List<String> rawAdvancemenNames;
+    private List<String> advancementNames;
+
+    public GuiEditMenuAdvancement (GuiQuestBook gui, QuestTaskAdvancement task, final QuestTaskAdvancement.AdvancementTask advancement, int id, EntityPlayer player) {
+        super(gui, player, false, 180, 70, 180, 150);
+        this.task = task;
+        this.advancement = advancement;
+        this.id = id;
+
+        scrollBar = new ScrollBar(160, 18, 186, 171, 69, START_X) {
+            @Override
+            public boolean isVisible(GuiBase gui) {
+                return advancementNames.size() > VISIBLE_MOBS;
+            }
+        };
+
+        textBoxes.add(new TextBoxGroup.TextBox(gui, "", 250, 18, false) {
+            @Override
+            public void textChanged(GuiBase gui) {
+                super.textChanged(gui);
+                updateAdvancements(getText());
+            }
+        });
+
+        rawAdvancemenNames = new ArrayList<>();
+        advancementNames = new ArrayList<>();
+
+        // Just using this to gain access to the advancement manager
+        WorldServer world = DimensionManager.getWorld(0);
+
+        for (Advancement a: world.getAdvancementManager().getAdvancements()) {
+            String adv = a.getId().toString();
+            rawAdvancemenNames.add(adv);
+            advancementNames.add(adv);
+        }
+
+        Collections.sort(advancementNames);
+        updateAdvancements("");
+    }
+
+    private void updateAdvancements(String search) {
+        if (advancementNames != null) {
+            advancementNames.clear();
+            for (String rawAdv : rawAdvancemenNames) {
+                if (rawAdv.toLowerCase().contains(search.toLowerCase())) {
+                    advancementNames.add(rawAdv);
+                }
+            }
+
+            Collections.sort(advancementNames);
+        }
+    }
+
+    @Override
+    public void draw(GuiBase gui, int mX, int mY) {
+        super.draw(gui, mX, mY);
+
+        ResourceHelper.bindResource(GuiQuestBook.MAP_TEXTURE);
+        GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
+        scrollBar.draw(gui);
+
+        int start = scrollBar.isVisible(gui) ? Math.round((advancementNames.size() - VISIBLE_MOBS) * scrollBar.getScroll()) : 0;
+        int end = Math.min(advancementNames.size(), start + VISIBLE_MOBS);
+        for (int i = start; i < end; i++) {
+             boolean selected = advancementNames.get(i).equals(advancement.getName());
+             boolean inBounds = gui.inBounds(START_X, START_Y + (i - start) * OFFSET_Y, 130, 6, mX, mY);
+
+             gui.drawString(advancementNames.get(i), START_X, START_Y + OFFSET_Y * (i - start), 0.7F, selected ? inBounds ? 0xC0C0C0 : 0xA0A0A0 : inBounds ? 0x707070 : 0x404040);
+        }
+
+        gui.drawString("Search", 180, 20, 0x404040);
+        gui.drawString(((advancement.getAdvancement() == null) ? "Nothing" : "Currently") + "Selected", 180, 40, 0x404040);
+        if (advancement.getAdvancement() != null) {
+             gui.drawString(advancement.getAdvancement(), 180, 50, 0.7F, 0x404040);
+        }
+    }
+
+    @Override
+    public void onClick(GuiBase gui, int mX, int mY, int b) {
+        super.onClick(gui, mX, mY, b);
+
+        scrollBar.onClick(gui, mX, mY);
+
+          int start = scrollBar.isVisible(gui) ? Math.round((advancementNames.size() - VISIBLE_MOBS) * scrollBar.getScroll()) : 0;
+         int end = Math.min(advancementNames.size(), start + VISIBLE_MOBS);
+         for (int i = start; i < end; i++) {
+             if (gui.inBounds(START_X, START_Y + (i - start) * OFFSET_Y, 130, 6, mX, mY)) {
+
+                 if (advancement.getAdvancement() != null && advancementNames.get(i).equals(advancement.getAdvancement())) {
+                     advancement.unsetAdvancement();
+                 } else {
+                     advancement.setAdvancement(advancementNames.get(i));
+                 }
+                 break;
+             }
+         }
+    }
+
+    @Override
+    public void onRelease(GuiBase gui, int mX, int mY) {
+        super.onRelease(gui, mX, mY);
+
+        scrollBar.onRelease(gui, mX, mY);
+    }
+
+    @Override
+    protected void onArrowClick(boolean left) {
+    }
+
+    @Override
+    protected String getArrowText() {
+        return "Exact Advancement";
+    }
+
+    @Override
+    protected String getArrowDescription() {
+        return "Completing the exact advancement is required.";
+    }
+
+    @Override
+    public void onDrag(GuiBase gui, int mX, int mY) {
+        super.onDrag(gui, mX, mY);
+        scrollBar.onDrag(gui, mX, mY);
+    }
+
+    @Override
+    public void onScroll(GuiBase gui, int mX, int mY, int scroll) {
+        super.onScroll(gui, mX, mY, scroll);
+        scrollBar.onScroll(gui, mX, mY, scroll);
+    }
+
+    @Override
+    public void save(GuiBase gui) {
+        task.setAdvancement(id, advancement, player);
+    }
+}
+

--- a/src/main/java/hardcorequesting/client/interfaces/edit/GuiEditMenuItem.java
+++ b/src/main/java/hardcorequesting/client/interfaces/edit/GuiEditMenuItem.java
@@ -327,6 +327,7 @@ public class GuiEditMenuItem extends GuiEditMenu {
         LOCATION(false, false, false),
         TAME(false, false, false),
         MOB(false, false, false),
+        ADVANCEMENT(false, false, false),
         PORTAL(false, false, false);
 
 

--- a/src/main/java/hardcorequesting/client/interfaces/edit/GuiEditMenuTextEditor.java
+++ b/src/main/java/hardcorequesting/client/interfaces/edit/GuiEditMenuTextEditor.java
@@ -8,10 +8,7 @@ import hardcorequesting.client.interfaces.LargeButton;
 import hardcorequesting.client.interfaces.TextBoxLogic;
 import hardcorequesting.quests.Quest;
 import hardcorequesting.quests.QuestSet;
-import hardcorequesting.quests.task.QuestTask;
-import hardcorequesting.quests.task.QuestTaskLocation;
-import hardcorequesting.quests.task.QuestTaskMob;
-import hardcorequesting.quests.task.QuestTaskTame;
+import hardcorequesting.quests.task.*;
 import hardcorequesting.reputation.Reputation;
 import hardcorequesting.reputation.ReputationMarker;
 import hardcorequesting.util.SaveHelper;
@@ -40,6 +37,7 @@ public class GuiEditMenuTextEditor extends GuiEditMenu {
     private int location = -1;
     private int mob = -1;
     private int tame = -1;
+    private int advancementId = -1;
     private boolean isName;
 
     protected GuiEditMenuTextEditor(GuiQuestBook gui, EntityPlayer player, String txt, boolean isName) {
@@ -164,6 +162,12 @@ public class GuiEditMenuTextEditor extends GuiEditMenu {
         this.location = id;
     }
 
+    public GuiEditMenuTextEditor(GuiQuestBook gui, EntityPlayer player, QuestTaskAdvancement task, int id, QuestTaskAdvancement.AdvancementTask advancement) {
+        this(gui, player, advancement.getName(), true);
+        this.task = task;
+        this.advancementId = id;
+    }
+
     public GuiEditMenuTextEditor(GuiQuestBook gui, EntityPlayer player, QuestTaskTame task, int id, QuestTaskTame.Tame tame) {
         this(gui, player, tame.getName(), true);
         this.task = task;
@@ -234,6 +238,11 @@ public class GuiEditMenuTextEditor extends GuiEditMenu {
                     str = str.substring(0, str.length() - 1);
                 }
                 ((QuestTaskMob) task).setName(mob, str, player);
+            } else if (advancementId != -1) {
+                 while (gui.getStringWidth(str) > 110) {
+                     str = str.substring(0, str.length() -1);
+                 }
+                ((QuestTaskAdvancement) task).setName(advancementId, str, player);
             } else if (isName) {
                 task.setDescription(str);
             } else {

--- a/src/main/java/hardcorequesting/event/EventTrigger.java
+++ b/src/main/java/hardcorequesting/event/EventTrigger.java
@@ -6,6 +6,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.living.AnimalTameEvent;
 import net.minecraftforge.event.entity.living.LivingDeathEvent;
+import net.minecraftforge.event.entity.player.AdvancementEvent;
 import net.minecraftforge.event.entity.player.EntityItemPickupEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
@@ -113,6 +114,13 @@ public class EventTrigger{
         }
     }
 
+    @SubscribeEvent
+    public void onEvent(AdvancementEvent event) {
+        for (QuestTask task : getTasks(Type.ADVANCEMENT)) {
+            task.onAdvancement(event);
+        }
+    }
+
 
     private List<QuestTask> getTasks(Type type) {
         return registeredTasks[type.ordinal()];
@@ -127,6 +135,7 @@ public class EventTrigger{
         OPEN_BOOK,
         REPUTATION_CHANGE,
         ANIMAL_TAME,
+        ADVANCEMENT,
     }
 
     public static class BookOpeningEvent {

--- a/src/main/java/hardcorequesting/quests/Quest.java
+++ b/src/main/java/hardcorequesting/quests/Quest.java
@@ -160,12 +160,12 @@ public class Quest {
         buttons.add(new LargeButton("hqm.quest.manualSubmit", 185, 200) {
             @Override
             public boolean isEnabled(GuiBase gui, EntityPlayer player) {
-                return ((QuestTaskItemsConsume) selectedTask).allowManual();
+                return selectedTask.allowManual();
             }
 
             @Override
             public boolean isVisible(GuiBase gui, EntityPlayer player) {
-                return selectedTask != null && selectedTask instanceof QuestTaskItemsConsume && !selectedTask.isCompleted(player);
+                return selectedTask != null && selectedTask.allowManual() && !selectedTask.isCompleted(player);
             }
 
             @Override
@@ -177,12 +177,12 @@ public class Quest {
         buttons.add(new LargeButton("hqm.quest.manualDetect", 185, 200) {
             @Override
             public boolean isEnabled(GuiBase gui, EntityPlayer player) {
-                return true;
+                return selectedTask.allowDetect();
             }
 
             @Override
             public boolean isVisible(GuiBase gui, EntityPlayer player) {
-                return selectedTask != null && selectedTask instanceof QuestTaskItemsDetect && !selectedTask.isCompleted(player);
+                return selectedTask != null && selectedTask.allowDetect() && !selectedTask.isCompleted(player);
             }
 
             @Override
@@ -1453,6 +1453,8 @@ public class Quest {
             ((QuestTaskLocation) selectedTask).setIcon(id, (ItemStack) element.getFluidStack(), player);
         } else if (selectedTask instanceof QuestTaskTame && type == GuiEditMenuItem.Type.TAME) {
             ((QuestTaskTame) selectedTask).setIcon(id, (ItemStack) element.getFluidStack(), player);
+        } else if (selectedTask instanceof QuestTaskAdvancement && type == GuiEditMenuItem.Type.ADVANCEMENT) {
+            ((QuestTaskAdvancement) selectedTask).setIcon(id, (ItemStack) element.getFluidStack(), player);
         } else if (selectedTask instanceof QuestTaskMob && type == GuiEditMenuItem.Type.MOB) {
             ((QuestTaskMob) selectedTask).setIcon(id, (ItemStack) element.getFluidStack(), player);
         }
@@ -1644,7 +1646,8 @@ public class Quest {
         TAME(QuestTaskTame.class, "tame"),
         DEATH(QuestTaskDeath.class, "death"),
         REPUTATION(QuestTaskReputationTarget.class, "reputation"),
-        REPUTATION_KILL(QuestTaskReputationKill.class, "reputationKill");
+        REPUTATION_KILL(QuestTaskReputationKill.class, "reputationKill"),
+        ADVANCEMENT(QuestTaskAdvancement.class, "advancement");
 
         private final Class<? extends QuestTask> clazz;
         private final String id;

--- a/src/main/java/hardcorequesting/quests/data/QuestDataTaskAdvancement.java
+++ b/src/main/java/hardcorequesting/quests/data/QuestDataTaskAdvancement.java
@@ -1,0 +1,76 @@
+package hardcorequesting.quests.data;
+
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import hardcorequesting.io.adapter.QuestTaskAdapter;
+import hardcorequesting.quests.task.QuestTask;
+import hardcorequesting.quests.task.QuestTaskAdvancement;
+
+  import java.io.IOException;
+
+  public class QuestDataTaskAdvancement extends QuestDataTask {
+
+      private static final String COUNT = "count";
+     private static final String ADVANCED = "advanced";
+     public boolean[] advanced;
+
+      public QuestDataTaskAdvancement(QuestTask task) {
+         super(task);
+         this.advanced = new boolean[((QuestTaskAdvancement) task).advancements.length];
+     }
+
+      protected QuestDataTaskAdvancement() {
+         super();
+         this.advanced = new boolean[0];
+     }
+
+      public static QuestDataTask construct(JsonReader in) {
+         QuestDataTaskAdvancement taskData = new QuestDataTaskAdvancement();
+         try {
+             int count = 0;
+             while (in.hasNext()) {
+                 switch (in.nextName()) {
+                     case QuestDataTask.COMPLETED:
+                         taskData.completed = in.nextBoolean();
+                         break;
+                     case COUNT:
+                         count = in.nextInt();
+                         taskData.advanced = new boolean[count];
+                         break;
+                     case ADVANCED:
+                         in.beginArray();
+                         for (int i = 0; i < count; i++)
+                             taskData.advanced[i] = in.nextBoolean();
+                         in.endArray();
+                         break;
+                     default:
+                         break;
+                 }
+             }
+         } catch (IOException ignored) {
+         }
+         return taskData;
+     }
+
+      @Override
+     public QuestTaskAdapter.QuestDataType getDataType() {
+         return QuestTaskAdapter.QuestDataType.ADVANCEMENT;
+     }
+
+      @Override
+     public void write(JsonWriter out) throws IOException {
+         super.write(out);
+         out.name(COUNT).value(advanced.length);
+         out.name(ADVANCED).beginArray();
+         for (boolean i : advanced)
+             out.value(i);
+         out.endArray();
+     }
+
+      @Override
+     public void update(QuestDataTask taskData) {
+         super.update(taskData);
+         this.advanced = ((QuestDataTaskAdvancement) taskData).advanced;
+     }
+ }
+

--- a/src/main/java/hardcorequesting/quests/task/QuestTask.java
+++ b/src/main/java/hardcorequesting/quests/task/QuestTask.java
@@ -22,6 +22,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraftforge.event.entity.living.AnimalTameEvent;
 import net.minecraftforge.event.entity.living.LivingDeathEvent;
+import net.minecraftforge.event.entity.player.AdvancementEvent;
 import net.minecraftforge.event.entity.player.EntityItemPickupEvent;
 import net.minecraftforge.fml.common.gameevent.PlayerEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
@@ -95,6 +96,14 @@ public abstract class QuestTask {
 
     public void updateId() {
         this.id = parent.nextTaskId++;
+    }
+
+    public boolean allowManual () {
+        return false;
+    }
+
+    public boolean allowDetect () {
+        return false;
     }
 
     public boolean isCompleted(EntityPlayer player) {
@@ -275,6 +284,8 @@ public abstract class QuestTask {
     }
 
     public void onAnimalTame(AnimalTameEvent event) {
+    }
 
+    public void onAdvancement(AdvancementEvent event) {
     }
 }

--- a/src/main/java/hardcorequesting/quests/task/QuestTaskAdvancement.java
+++ b/src/main/java/hardcorequesting/quests/task/QuestTaskAdvancement.java
@@ -1,0 +1,339 @@
+package hardcorequesting.quests.task;
+
+import hardcorequesting.client.EditMode;
+import hardcorequesting.client.interfaces.GuiColor;
+import hardcorequesting.client.interfaces.GuiQuestBook;
+import hardcorequesting.client.interfaces.edit.GuiEditMenuAdvancement;
+import hardcorequesting.client.interfaces.edit.GuiEditMenuItem;
+import hardcorequesting.client.interfaces.edit.GuiEditMenuTextEditor;
+import hardcorequesting.event.EventTrigger;
+import hardcorequesting.quests.ItemPrecision;
+import hardcorequesting.quests.Quest;
+import hardcorequesting.quests.data.QuestDataTask;
+import hardcorequesting.quests.data.QuestDataTaskAdvancement;
+import hardcorequesting.util.SaveHelper;
+import hardcorequesting.util.Translator;
+import net.minecraft.advancements.Advancement;
+import net.minecraft.advancements.AdvancementManager;
+import net.minecraft.advancements.AdvancementProgress;
+import net.minecraft.advancements.PlayerAdvancements;
+import net.minecraft.client.Minecraft;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.World;
+import net.minecraftforge.event.entity.player.AdvancementEvent;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+import org.apache.commons.lang3.ArrayUtils;
+
+import javax.annotation.Nonnull;
+import java.util.Arrays;
+import java.util.UUID;
+
+public class QuestTaskAdvancement extends QuestTask {
+    private static final int Y_OFFSET = 30;
+    private static final int X_TEXT_OFFSET = 23;
+    private static final int X_TEXT_INDENT = 0;
+    private static final int Y_TEXT_OFFSET = 0;
+    private static final int ITEM_SIZE = 18;
+    public AdvancementTask[] advancements = new AdvancementTask[0];
+
+    public QuestTaskAdvancement(Quest parent, String description, String longDescription) {
+        super(parent, description, longDescription);
+
+        register(EventTrigger.Type.ADVANCEMENT, EventTrigger.Type.OPEN_BOOK);
+    }
+
+    @SideOnly(Side.CLIENT)
+    private AdvancementTask[] getEditFriendlyAdvancements(AdvancementTask[] advancements) {
+        if (Quest.canQuestsBeEdited(Minecraft.getMinecraft().player)) {
+            advancements = Arrays.copyOf(advancements, advancements.length + 1);
+            advancements[advancements.length - 1] = new AdvancementTask();
+            return advancements;
+        } else {
+            return advancements;
+        }
+    }
+
+    private boolean advanced(int id, EntityPlayer player) {
+        return id < advancements.length && ((QuestDataTaskAdvancement) getData(player)).advanced[id];
+    }
+
+    public void setAdvancement(int id, AdvancementTask advancement, EntityPlayer player) {
+        if (id >= advancements.length) {
+            advancements = Arrays.copyOf(advancements, advancements.length + 1);
+            QuestDataTaskAdvancement data = (QuestDataTaskAdvancement) getData(player);
+            data.advanced = Arrays.copyOf(data.advanced, data.advanced.length + 1);
+            SaveHelper.add(SaveHelper.EditType.LOCATION_CREATE);
+        } else {
+            SaveHelper.add(SaveHelper.EditType.LOCATION_CHANGE);
+        }
+
+        advancements[id] = advancement;
+    }
+
+    public void setIcon(int id, ItemStack stack, EntityPlayer player) {
+        setAdvancement(id, id >= advancements.length ? new AdvancementTask() : advancements[id], player);
+
+        advancements[id].iconStack = stack;
+    }
+
+    public void setName(int id, String str, EntityPlayer player) {
+        setAdvancement(id, id >= advancements.length ? new AdvancementTask() : advancements[id], player);
+
+        advancements[id].name = str;
+    }
+
+    @Override
+    public Class<? extends QuestDataTask> getDataType() {
+        return QuestDataTaskAdvancement.class;
+    }
+
+    @SideOnly(Side.CLIENT)
+    @Override
+    public void draw(GuiQuestBook gui, EntityPlayer player, int mX, int mY) {
+        AdvancementTask[] advancements = getEditFriendlyAdvancements(this.advancements);
+        for (int i = 0; i < advancements.length; i++) {
+            AdvancementTask advancement = advancements[i];
+
+            int x = START_X;
+            int y = START_Y + i * Y_OFFSET;
+            gui.drawItemStack(advancement.iconStack, x, y, mX, mY, false);
+            gui.drawString(advancement.name, x + X_TEXT_OFFSET, y + Y_TEXT_OFFSET, 0x404040);
+
+            if (advanced(i, player)) {
+                gui.drawString(GuiColor.GREEN + Translator.translate("hqm.advancementMenu.visited"), x + X_TEXT_OFFSET + X_TEXT_INDENT, y + Y_TEXT_OFFSET + 9, 0.7F, 0x404040);
+            }
+        }
+    }
+
+    @SideOnly(Side.CLIENT)
+    @Override
+    public void onClick(GuiQuestBook gui, EntityPlayer player, int mX, int mY, int b) {
+        if (Quest.canQuestsBeEdited(player) && gui.getCurrentMode() != EditMode.NORMAL) {
+            AdvancementTask[] advancements = getEditFriendlyAdvancements(this.advancements);
+            for (int i = 0; i < advancements.length; i++) {
+                AdvancementTask advancement = advancements[i];
+
+                int x = START_X;
+                int y = START_Y + i * Y_OFFSET;
+
+                if (gui.inBounds(x, y, ITEM_SIZE, ITEM_SIZE, mX, mY)) {
+                    switch (gui.getCurrentMode()) {
+                        case LOCATION:
+                            gui.setEditMenu(new GuiEditMenuAdvancement(gui, this, advancement.copy(), i, player));
+                            break;
+                        case ITEM:
+                            gui.setEditMenu(new GuiEditMenuItem(gui, player, advancement.iconStack, i, GuiEditMenuItem.Type.ADVANCEMENT, 1, ItemPrecision.PRECISE));
+                            break;
+                        case RENAME:
+                            gui.setEditMenu(new GuiEditMenuTextEditor(gui, player, this, i, advancement));
+                            break;
+                        case DELETE:
+                            if (i < this.advancements.length) {
+                                AdvancementTask[] newAdvancements = new AdvancementTask[this.advancements.length - 1];
+                                int id = 0;
+                                for (int j = 0; j < this.advancements.length; j++) {
+                                    if (j != i) {
+                                        newAdvancements[id] = this.advancements[j];
+                                        id++;
+                                    }
+                                }
+                                this.advancements = newAdvancements;
+                                SaveHelper.add(SaveHelper.EditType.LOCATION_REMOVE);
+                            }
+                            break;
+                        default:
+                    }
+
+                    break;
+                }
+            }
+        }
+    }
+
+    @Override
+    public void onAdvancement(AdvancementEvent event) {
+        checkAdvancement(event.getEntityPlayer());
+    }
+
+    @Override
+    public void onUpdate(EntityPlayer player) {
+        checkAdvancement(player);
+    }
+
+    private void checkAdvancement(EntityPlayer player) {
+        World world = player.getEntityWorld();
+        if (!world.isRemote && !this.isCompleted(player) && player.getServer() != null) {
+            boolean[] advanced = ((QuestDataTaskAdvancement) this.getData(player)).advanced;
+
+            if (advanced.length < advancements.length) {
+                boolean[] oldVisited = ArrayUtils.addAll(advanced, (boolean[]) null);
+                advanced = new boolean[advancements.length];
+                System.arraycopy(oldVisited, 0, advanced, 0, oldVisited.length);
+                ((QuestDataTaskAdvancement) this.getData(player)).advanced = advanced;
+            }
+
+            boolean completed = true;
+            AdvancementManager manager = player.getServer().getAdvancementManager();
+            PlayerAdvancements playerAdvancements = player.getServer().getPlayerList().getPlayerAdvancements((EntityPlayerMP) player);
+
+            for (int i = 0; i < advancements.length; i++) {
+                if (advanced[i]) continue;
+
+                AdvancementTask advancement = this.advancements[i];
+                if (advancement == null) continue;
+
+                ResourceLocation advResource = new ResourceLocation(advancement.getAdvancement());
+
+                Advancement advAdvancement = manager.getAdvancement(advResource);
+
+                AdvancementProgress progress = playerAdvancements.getProgress(advAdvancement);
+
+                if (progress.isDone()) {
+                    advanced[i] = true;
+                } else {
+                    completed = false;
+                }
+            }
+
+            if (completed && advancements.length > 0) {
+                completeTask(player.getUniqueID());
+                parent.sendUpdatedDataToTeam(player);
+            }
+        }
+    }
+
+    @Override
+    public float getCompletedRatio(UUID uuid) {
+        int advanced = 0;
+        for (boolean b : ((QuestDataTaskAdvancement) getData(uuid)).advanced) {
+            if (b) {
+                advanced++;
+            }
+        }
+
+        return (float) advanced / advancements.length;
+    }
+
+    @Override
+    public void mergeProgress(UUID uuid, QuestDataTask own, QuestDataTask other) {
+        boolean[] advanced = ((QuestDataTaskAdvancement) own).advanced;
+        boolean[] otherVisited = ((QuestDataTaskAdvancement) other).advanced;
+
+        boolean all = true;
+        for (int i = 0; i < advanced.length; i++) {
+            if (otherVisited[i]) {
+                advanced[i] = true;
+            } else if (!advanced[i]) {
+                all = false;
+            }
+        }
+
+        if (all) {
+            completeTask(uuid);
+        }
+    }
+
+    @Override
+    public void autoComplete(UUID uuid) {
+        boolean[] advanced = ((QuestDataTaskAdvancement) getData(uuid)).advanced;
+        for (int i = 0; i < advanced.length; i++) {
+            advanced[i] = true;
+        }
+    }
+
+    @Override
+    public void copyProgress(QuestDataTask own, QuestDataTask other) {
+        super.copyProgress(own, other);
+        boolean[] advanced = ((QuestDataTaskAdvancement) own).advanced;
+        System.arraycopy(((QuestDataTaskAdvancement) other).advanced, 0, advanced, 0, advanced.length);
+    }
+
+    @Override
+    public boolean allowDetect () {
+        return true;
+    }
+
+    public enum Visibility {
+        FULL("Full"),
+        NONE("None");
+
+        private String id;
+
+        Visibility(String id) {
+            this.id = id;
+        }
+
+        // TODO: fix these
+        public String getName() {
+            return Translator.translate("hqm.locationMenu.vis" + id + ".title");
+        }
+
+        public String getDescription() {
+            return Translator.translate("hqm.locationMenu.vis" + id + ".desc");
+        }
+    }
+
+    public static class AdvancementTask {
+
+        private ItemStack iconStack = ItemStack.EMPTY;
+        private String name = "New";
+        private Visibility visible = Visibility.FULL;
+        private String adv_name;
+
+        // TODO: Implement the actual storing of the advancement
+        private AdvancementTask copy() {
+            AdvancementTask advancement = new AdvancementTask();
+            advancement.iconStack = iconStack.isEmpty() ? ItemStack.EMPTY : iconStack.copy();
+            advancement.name = name;
+            advancement.visible = visible;
+            advancement.adv_name = adv_name;
+
+            return advancement;
+        }
+
+        public ItemStack getIconStack() {
+            return iconStack;
+        }
+
+        public void setIconStack(@Nonnull ItemStack iconStack) {
+            this.iconStack = iconStack;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public Visibility getVisible() {
+            return visible;
+        }
+
+        public void setVisible(Visibility visible) {
+            this.visible = visible;
+        }
+
+        public void setAdvancement(String name) {
+            this.adv_name = name;
+        }
+
+        public String getAdvancement() {
+            return this.adv_name;
+        }
+
+        public void setAdvancement(ResourceLocation name) {
+            setAdvancement(name.toString());
+        }
+
+        public void unsetAdvancement() {
+            this.adv_name = null;
+        }
+    }
+}
+

--- a/src/main/java/hardcorequesting/quests/task/QuestTaskItemsConsume.java
+++ b/src/main/java/hardcorequesting/quests/task/QuestTaskItemsConsume.java
@@ -57,6 +57,7 @@ public class QuestTaskItemsConsume extends QuestTaskItems {
         return GuiEditMenuItem.Type.CONSUME_TASK;
     }
 
+    @Override
     public boolean allowManual() {
         return true;
     }

--- a/src/main/java/hardcorequesting/quests/task/QuestTaskItemsDetect.java
+++ b/src/main/java/hardcorequesting/quests/task/QuestTaskItemsDetect.java
@@ -121,5 +121,9 @@ public class QuestTaskItemsDetect extends QuestTaskItems {
         }
     }
 
+    @Override
+    public boolean allowDetect () {
+        return true;
+    }
 
 }

--- a/src/main/resources/assets/hardcorequesting/lang/en_US.lang
+++ b/src/main/resources/assets/hardcorequesting/lang/en_US.lang
@@ -159,6 +159,8 @@ hqm.taskType.reputationKill.title=Rep kill task
 hqm.taskType.reputationKill.desc=A task where the player has to kill other players with certain reputations.
 hqm.taskType.tame.title=Taming task
 hqm.taskType.tame.desc=A task where the player has to tame specific creatures.
+hqm.taskType.advancement.title=Advancement task
+hqm.taskType.advancement.desc=A task where the player has to complete a specific advancement.
 
 # ======================================
 #			DEATH TYPES
@@ -579,6 +581,10 @@ hqm.locationMenu.visited=Visited
 hqm.locationMenu.mAway=%sm away
 hqm.locationMenu.mRadius=%sm radius
 hqm.locationMenu.wrongDim=Wrong dimension
+# ======================================
+#		  ADVANCEMENT MENU
+# ======================================
+hqm.advancementMenu.visited=Completed
 
 # ======================================
 #		    REPEAT MENU


### PR DESCRIPTION
Tested in single-player and in a dedicated client/server to make sure
everything is working properly.

Consumption tasks which previously used the allowManua() boolean method
now override that method, which is defined in QuestTask with a default
of false.

Detection tasks now check for allowDetect (also defined in QuestTask as
per above, with a default of false), instead of relying on instance of
Item Detection tasks.

Advancement task: use the "Location" mode button to change an
Advancement task, and select from any of the registered Advancements.

The task triggers either manually, or whenever the player achieves that
specific advancement.