### PR TITLE
Quest repeat fixes

### DIFF
--- a/common/src/main/java/hardcorequesting/common/io/adapter/QuestAdapter.java
+++ b/common/src/main/java/hardcorequesting/common/io/adapter/QuestAdapter.java
@@ -47,8 +47,8 @@ public class QuestAdapter {
             
             return new RepeatInfo(
                     RepeatType.valueOf(GsonHelper.getAsString(object, TYPE)),
-                    GsonHelper.getAsInt(object, HOURS, 0),
-                    GsonHelper.getAsInt(object, DAYS, 0)
+                    GsonHelper.getAsInt(object, DAYS, 0),
+                    GsonHelper.getAsInt(object, HOURS, 0)
             );
         }
     };

--- a/common/src/main/java/hardcorequesting/common/io/adapter/QuestDataAdapter.java
+++ b/common/src/main/java/hardcorequesting/common/io/adapter/QuestDataAdapter.java
@@ -68,7 +68,7 @@ public class QuestDataAdapter {
                         data.available = in.nextBoolean();
                         break;
                     case TIME:
-                        data.time = in.nextInt();
+                        data.time = in.nextLong();
                         break;
                     case TASKS_SIZE:
                         data.tasks = new QuestDataTask[in.nextInt()];

--- a/common/src/main/java/hardcorequesting/common/io/adapter/TeamAdapter.java
+++ b/common/src/main/java/hardcorequesting/common/io/adapter/TeamAdapter.java
@@ -117,7 +117,7 @@ public class TeamAdapter {
     public static void commitInvitesMap() {
         if (invitesMap.size() > 0) {
             Map<UUID, Team> tempMap = new HashMap<>();
-            StreamSupport.stream(TeamManager.getInstance().getTeams().spliterator(), false).filter(Objects::nonNull).forEach(team -> tempMap.put(team.getId(), team));
+            StreamSupport.stream(TeamManager.getInstance().getNamedTeams().spliterator(), false).filter(Objects::nonNull).forEach(team -> tempMap.put(team.getId(), team));
             for (Team team : TeamManager.getInstance().getTeams()) {
                 List<UUID> invites = invitesMap.get(team);
                 if (invites != null)

--- a/common/src/main/java/hardcorequesting/common/quests/Quest.java
+++ b/common/src/main/java/hardcorequesting/common/quests/Quest.java
@@ -1575,7 +1575,7 @@ public class Quest {
         }
     }
     
-    public void resetOnTime(int time) {
+    public void resetOnTime(long time) {
         for (Team team : TeamManager.getInstance().getTeams()) {
             QuestData data = team.getQuestData(getQuestId());
             if (data != null && !data.available && data.time <= time) {

--- a/common/src/main/java/hardcorequesting/common/quests/QuestData.java
+++ b/common/src/main/java/hardcorequesting/common/quests/QuestData.java
@@ -13,7 +13,7 @@ public class QuestData {
     public boolean claimed;
     public QuestDataTask[] tasks;
     public boolean available = true;
-    public int time;
+    public long time;
     
     public QuestData(int players) {
         reward = new boolean[players];

--- a/common/src/main/java/hardcorequesting/common/quests/QuestLine.java
+++ b/common/src/main/java/hardcorequesting/common/quests/QuestLine.java
@@ -156,7 +156,7 @@ public class QuestLine {
                     NetworkManager.sendToPlayer(new QuestLineSyncMessage(questLine), serverPlayer);
             }
             NetworkManager.sendToPlayer(new DeathStatsMessage(side), serverPlayer);
-            NetworkManager.sendToPlayer(new TeamStatsMessage(StreamSupport.stream(questLine.teamManager.getTeams().spliterator(), false)), serverPlayer);
+            NetworkManager.sendToPlayer(new TeamStatsMessage(StreamSupport.stream(questLine.teamManager.getNamedTeams().spliterator(), false)), serverPlayer);
         }
     }
     

--- a/common/src/main/java/hardcorequesting/common/quests/QuestTicker.java
+++ b/common/src/main/java/hardcorequesting/common/quests/QuestTicker.java
@@ -27,6 +27,8 @@ public class QuestTicker {
                         }
                     } else if (quest.getRepeatInfo().getType() == RepeatType.TIME) {
                         quest.resetOnTime(hours - total);
+                    } else if (quest.getRepeatInfo().getType() == RepeatType.INSTANT) {
+                        quest.resetAll();
                     }
                 }
             }

--- a/common/src/main/java/hardcorequesting/common/quests/QuestTicker.java
+++ b/common/src/main/java/hardcorequesting/common/quests/QuestTicker.java
@@ -1,23 +1,22 @@
 package hardcorequesting.common.quests;
 
 import hardcorequesting.common.HardcoreQuestingCore;
+import net.minecraft.world.level.Level;
 
 public class QuestTicker {
     
-    private int hours;
-    private int ticks;
+    private long hours;
     
     public QuestTicker(boolean isClient) {
         if (isClient) {
-            HardcoreQuestingCore.platform.registerOnClientTick(minecraftClient -> tick(true));
-        }
-        HardcoreQuestingCore.platform.registerOnServerTick(minecraftClient -> tick(false));
+            HardcoreQuestingCore.platform.registerOnClientTick(minecraftClient -> tick(minecraftClient.level, true));
+        } else
+            HardcoreQuestingCore.platform.registerOnServerTick(minecraftServer -> tick(minecraftServer.overworld(), false));
     }
     
-    public void tick(boolean isClient) {
-        if (++ticks == 1000) {
-            ticks = 0;
-            hours++;
+    public void tick(Level level, boolean isClient) {
+        if (level != null && level.getGameTime() / 1000 != hours) {
+            hours = level.getGameTime() / 1000;
             if (!isClient) {
                 for (Quest quest : Quest.getQuests().values()) {
                     int total = quest.getRepeatInfo().getDays() * 24 + quest.getRepeatInfo().getHours();
@@ -35,8 +34,7 @@ public class QuestTicker {
         }
     }
     
-    
-    public int getHours() {
+    public long getHours() {
         return hours;
     }
 }

--- a/common/src/main/java/hardcorequesting/common/quests/QuestingData.java
+++ b/common/src/main/java/hardcorequesting/common/quests/QuestingData.java
@@ -230,7 +230,7 @@ public class QuestingData {
         QuestingDataManager manager = QuestingDataManager.getInstance();
         QuestingData data = manager.getQuestingData(player);
         Team team = data.getTeam();
-        if (!team.isSingle() && !Iterables.isEmpty(TeamManager.getInstance().getTeams())) {
+        if (!team.isSingle() && !Iterables.isEmpty(TeamManager.getInstance().getNamedTeams())) {
             team.removePlayer(player);
             if (team.getPlayerCount() == 0) {
                 team.deleteTeam();

--- a/common/src/main/java/hardcorequesting/common/quests/RepeatType.java
+++ b/common/src/main/java/hardcorequesting/common/quests/RepeatType.java
@@ -31,7 +31,7 @@ public enum RepeatType {
         @Environment(EnvType.CLIENT)
         @Override
         public String getMessage(Quest quest, Player player, int days, int hours) {
-            return super.getMessage(quest, player, days, hours) + GuiColor.GRAY + I18n.get("hqm.repeat.interval.message") + "\n" + formatTime(days, hours) + "\n" + formatResetTime(quest, player, days, hours);
+            return super.getMessage(quest, player, days, hours) + GuiColor.GRAY + I18n.get("hqm.repeat.interval.message") + "\n" + formatTime(days, hours) + "\n" + formatIntervalTime(quest, player, days, hours);
         }
     
         @Environment(EnvType.CLIENT)
@@ -44,7 +44,7 @@ public enum RepeatType {
         @Environment(EnvType.CLIENT)
         @Override
         public String getMessage(Quest quest, Player player, int days, int hours) {
-            return super.getMessage(quest, player, days, hours) + GuiColor.GRAY + I18n.get("hqm.repeat.time.message") + "\n" + formatTime(days, hours) + formatRemainingTime(quest, player, days, hours);
+            return super.getMessage(quest, player, days, hours) + GuiColor.GRAY + I18n.get("hqm.repeat.time.message") + "\n" + formatTime(days, hours) + formatCooldownTime(quest, player, days, hours);
         }
     
         @Environment(EnvType.CLIENT)
@@ -62,36 +62,48 @@ public enum RepeatType {
         this.useTime = useTime;
     }
     
+    /**
+     * Formats and produces text describing the reset time, given the cooldown time from a quest being finished to reset
+     */
     @Environment(EnvType.CLIENT)
-    private static String formatRemainingTime(Quest quest, Player player, int days, int hours) {
+    private static String formatCooldownTime(Quest quest, Player player, int days, int hours) {
         if (!quest.getQuestData(player).available) {
             int timerDuration = days * 24 + hours;
             long timerStart = quest.getQuestData(player).time;
             long current = Quest.clientTicker.getHours();
             int remaining = (int) (timerStart + timerDuration - current);
             
-            return "\n" + formatResetTime(quest, player, remaining / 24, remaining % 24);
+            return "\n" + formatRemainingTime(quest, player, remaining / 24, remaining % 24);
         } else {
             return "";
         }
     }
     
+    /**
+     * Formats and produces text describing the reset time, given the interval time between scheduled resets
+     */
     @Environment(EnvType.CLIENT)
-    private static String formatResetTime(Quest quest, Player player, int days, int hours) {
+    private static String formatIntervalTime(Quest quest, Player player, int days, int hours) {
         if (days == 0 && hours == 0) {
             return GuiColor.RED + I18n.get("hqm.repeat.invalid");
         }
         
-        int total = days * 24 + hours;
-        int resetHoursTotal = total - (int) (Quest.clientTicker.getHours() % total);
+        int interval = days * 24 + hours;
+        int remaining = interval - (int) (Quest.clientTicker.getHours() % interval);
         
-        int resetDays = resetHoursTotal / 24;
-        int resetHours = resetHoursTotal % 24;
+        return formatRemainingTime(quest, player, remaining / 24, remaining % 24);
+    }
+    
+    /**
+     * Formats and produces text describing the reset time, given the remaining time until the next reset
+     */
+    @Environment(EnvType.CLIENT)
+    private static String formatRemainingTime(Quest quest, Player player, int days, int hours) {
         
         if (!quest.isAvailable(player)) {
-            return GuiColor.YELLOW + I18n.get("hqm.repeat.resetIn", formatTime(resetDays, resetHours));
+            return GuiColor.YELLOW + I18n.get("hqm.repeat.resetIn", formatTime(days, hours));
         } else {
-            return GuiColor.GRAY + I18n.get("hqm.repeat.nextReset", formatTime(resetDays, resetHours));
+            return GuiColor.GRAY + I18n.get("hqm.repeat.nextReset", formatTime(days, hours));
         }
     }
     

--- a/common/src/main/java/hardcorequesting/common/quests/RepeatType.java
+++ b/common/src/main/java/hardcorequesting/common/quests/RepeatType.java
@@ -65,13 +65,12 @@ public enum RepeatType {
     @Environment(EnvType.CLIENT)
     private static String formatRemainingTime(Quest quest, Player player, int days, int hours) {
         if (!quest.getQuestData(player).available) {
-            int total = days * 24 + hours;
-            int time = quest.getQuestData(player).time;
-            int current = Quest.clientTicker.getHours();
+            int timerDuration = days * 24 + hours;
+            long timerStart = quest.getQuestData(player).time;
+            long current = Quest.clientTicker.getHours();
+            int remaining = (int) (timerStart + timerDuration - current);
             
-            total = time + total - current;
-            
-            return "\n" + formatResetTime(quest, player, total / 24, total % 24);
+            return "\n" + formatResetTime(quest, player, remaining / 24, remaining % 24);
         } else {
             return "";
         }
@@ -84,7 +83,7 @@ public enum RepeatType {
         }
         
         int total = days * 24 + hours;
-        int resetHoursTotal = total - Quest.clientTicker.getHours() % total;
+        int resetHoursTotal = total - (int) (Quest.clientTicker.getHours() % total);
         
         int resetDays = resetHoursTotal / 24;
         int resetHours = resetHoursTotal % 24;

--- a/common/src/main/java/hardcorequesting/common/team/TeamAction.java
+++ b/common/src/main/java/hardcorequesting/common/team/TeamAction.java
@@ -22,7 +22,7 @@ public enum TeamAction {
                     return;
                 }
                 
-                for (Team t : manager.getTeams()) {
+                for (Team t : manager.getNamedTeams()) {
                     if (t.getName().equals(teamName)) {
                         TeamError.USED_NAME.sendToClient(player);
                         return;

--- a/common/src/main/java/hardcorequesting/common/team/TeamManager.java
+++ b/common/src/main/java/hardcorequesting/common/team/TeamManager.java
@@ -1,5 +1,6 @@
 package hardcorequesting.common.team;
 
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.gson.reflect.TypeToken;
@@ -7,6 +8,7 @@ import hardcorequesting.common.HardcoreQuestingCore;
 import hardcorequesting.common.io.SaveHandler;
 import hardcorequesting.common.io.adapter.TeamAdapter;
 import hardcorequesting.common.quests.QuestLine;
+import hardcorequesting.common.quests.QuestingData;
 import hardcorequesting.common.quests.QuestingDataManager;
 import hardcorequesting.common.quests.SimpleSerializable;
 import net.minecraft.world.entity.player.Player;
@@ -83,8 +85,15 @@ public class TeamManager extends SimpleSerializable {
         return Team.single(playerId);
     }
     
-    public Iterable<Team> getTeams() {
+    public Iterable<Team> getNamedTeams() {
         return teams;
+    }
+    
+    public Iterable<Team> getTeams() {
+        //Collect any teams that are not managed by the TeamManager
+        Iterable<Team> singleTeams = QuestingDataManager.getInstance().getQuestingData().values().stream().map(QuestingData::getTeam)
+                .filter(Team::isSingle).collect(Collectors.toSet());
+        return Iterables.concat(teams, singleTeams);
     }
     
     public void deactivate() {

--- a/forge/src/main/java/hardcorequesting/forge/HardcoreQuestingForge.java
+++ b/forge/src/main/java/hardcorequesting/forge/HardcoreQuestingForge.java
@@ -195,17 +195,26 @@ public class HardcoreQuestingForge implements AbstractPlatform {
     
     @Override
     public void registerOnServerTick(Consumer<MinecraftServer> consumer) {
-        MinecraftForge.EVENT_BUS.<TickEvent.ServerTickEvent>addListener(event -> consumer.accept(getServer()));
+        MinecraftForge.EVENT_BUS.<TickEvent.ServerTickEvent>addListener(event -> {
+            if(event.phase == TickEvent.Phase.END)
+                consumer.accept(getServer());
+        });
     }
     
     @Override
     public void registerOnClientTick(Consumer<Minecraft> consumer) {
-        MinecraftForge.EVENT_BUS.<TickEvent.ClientTickEvent>addListener(event -> consumer.accept(Minecraft.getInstance()));
+        MinecraftForge.EVENT_BUS.<TickEvent.ClientTickEvent>addListener(event -> {
+            if(event.phase == TickEvent.Phase.END)
+                consumer.accept(Minecraft.getInstance());
+        });
     }
     
     @Override
     public void registerOnWorldTick(Consumer<Level> consumer) {
-        MinecraftForge.EVENT_BUS.<TickEvent.WorldTickEvent>addListener(event -> consumer.accept(event.world));
+        MinecraftForge.EVENT_BUS.<TickEvent.WorldTickEvent>addListener(event -> {
+            if(event.phase == TickEvent.Phase.END)
+                consumer.accept(event.world);
+        });
     }
     
     @Override


### PR DESCRIPTION
Fixes a collection of issues related to quest repetition:
- Fixed deserialisation of `RepeatInfo`, which previously had mixed up hours and days
- Made sure that the forge platform only responds to tick end when handling tick events, making it consistent with the fabric platform
- Changed client-side `QuestTicker` to only listen to client ticks 
- Changed `QuestTicker` to use `level.getGameTime()` as time measurement instead of ticking it internally, so that the time measurement is persistent with the world and synced with client-side. Quest completion time has accordingly changed to be a long value. (Part of fixing #544)
- Make sure that some mechanics (such as repeatable quest resetting) check all teams, and not just named teams  (Part of fixing #544)
- Reset quests with instant repeat on quest reset tick to fix any such quests that for any reason ended up in a completed, unavailable state
- Fix calculation of remaining time for cooldown repeat quests, and improve readability of reset time text formatting code

This pull request should be a complete fix for #544. Changes were made and tested under the changes from #551, but should be independent of it.