### PR TITLE
List for quest rewards

### DIFF
--- a/common/src/main/java/hardcorequesting/common/io/adapter/QuestAdapter.java
+++ b/common/src/main/java/hardcorequesting/common/io/adapter/QuestAdapter.java
@@ -14,6 +14,7 @@ import hardcorequesting.common.reputation.Reputation;
 import hardcorequesting.common.reputation.ReputationBar;
 import hardcorequesting.common.reputation.ReputationManager;
 import hardcorequesting.common.util.SaveHelper;
+import net.minecraft.core.NonNullList;
 import net.minecraft.util.GsonHelper;
 import net.minecraft.world.item.ItemStack;
 
@@ -141,7 +142,7 @@ public class QuestAdapter {
             return array.build();
         }
         
-        private JsonElement writeItemStackArray(ItemStack[] stacks) {
+        private JsonElement writeItemStackList(NonNullList<ItemStack> stacks) {
             JsonArrayBuilder array = array();
             if (stacks != null) {
                 for (ItemStack stack : stacks) {
@@ -191,8 +192,8 @@ public class QuestAdapter {
                     })
                     .add(PREREQUISITES, writeQuestList(src.getRequirements()))
                     .add(OPTIONLINKS, writeQuestList(src.getOptionLinks()))
-                    .add(REWARDS, writeItemStackArray(src.getReward()))
-                    .add(REWARDS_CHOICE, writeItemStackArray(src.getRewardChoice()))
+                    .add(REWARDS, writeItemStackList(src.getReward()))
+                    .add(REWARDS_CHOICE, writeItemStackList(src.getRewardChoice()))
                     .add(REWARDS_COMMAND, SaveHandler.GSON.toJsonTree(src.getCommandRewardsAsStrings()))
                     .build();
         }
@@ -231,8 +232,8 @@ public class QuestAdapter {
             for (JsonElement element : GsonHelper.getAsJsonArray(object, TASKS, EMPTY_ARRAY)) {
                 QuestTaskAdapter.TASK_ADAPTER.deserialize(element);
             }
-            QUEST.setReward(readItemStackArray(GsonHelper.getAsJsonArray(object, REWARDS, EMPTY_ARRAY)));
-            QUEST.setRewardChoice(readItemStackArray(GsonHelper.getAsJsonArray(object, REWARDS_CHOICE, EMPTY_ARRAY)));
+            QUEST.setReward(readItemStackList(GsonHelper.getAsJsonArray(object, REWARDS, EMPTY_ARRAY)));
+            QUEST.setRewardChoice(readItemStackList(GsonHelper.getAsJsonArray(object, REWARDS_CHOICE, EMPTY_ARRAY)));
             if (object.has(REWARDS_REPUTATION)) {
                 List<ReputationReward> reputationRewards = new ArrayList<>();
                 for (JsonElement element : GsonHelper.getAsJsonArray(object, REWARDS_REPUTATION, EMPTY_ARRAY)) {
@@ -261,14 +262,14 @@ public class QuestAdapter {
             }
         }
         
-        private ItemStack[] readItemStackArray(JsonArray array) {
-            List<ItemStack> stacks = new ArrayList<>();
+        private NonNullList<ItemStack> readItemStackList(JsonArray array) {
+            NonNullList<ItemStack> stacks = NonNullList.create();
             for (JsonElement element : array) {
                 ItemStack stack = MinecraftAdapter.ITEM_STACK.deserialize(element);
                 if (!stack.isEmpty())
                     stacks.add(stack);
             }
-            return stacks.toArray(new ItemStack[0]);
+            return stacks;
         }
     };
     public static final Adapter<QuestSet> QUEST_SET_ADAPTER = new Adapter<QuestSet>() {

--- a/common/src/main/java/hardcorequesting/common/quests/Quest.java
+++ b/common/src/main/java/hardcorequesting/common/quests/Quest.java
@@ -33,6 +33,7 @@ import net.fabricmc.api.Environment;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.core.NonNullList;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.FormattedText;
 import net.minecraft.network.chat.TranslatableComponent;
@@ -469,19 +470,19 @@ public class Quest {
         this.y = y;
     }
     
-    public ItemStack[] getReward() {
-        return rewards.toArray();
+    public NonNullList<ItemStack> getReward() {
+        return rewards.toList();
     }
     
-    public void setReward(ItemStack[] reward) {
+    public void setReward(NonNullList<ItemStack> reward) {
         this.rewards.set(reward);
     }
     
-    public ItemStack[] getRewardChoice() {
-        return rewardChoices.toArray();
+    public NonNullList<ItemStack> getRewardChoice() {
+        return rewardChoices.toList();
     }
     
-    public void setRewardChoice(ItemStack[] rewardChoice) {
+    public void setRewardChoice(NonNullList<ItemStack> rewardChoice) {
         this.rewardChoices.set(rewardChoice);
     }
     
@@ -903,14 +904,14 @@ public class Quest {
         }
         if (!rewards.isEmpty() || canQuestsBeEdited()) {
             gui.drawString(matrices, Translator.translatable("hqm.quest.rewards"), START_X, REWARD_STR_Y, 0x404040);
-            drawRewards(gui, rewards.toArray(), REWARD_Y, -1, mX, mY, MAX_SELECT_REWARD_SLOTS);
+            drawRewards(gui, rewards.toList(), REWARD_Y, -1, mX, mY, MAX_SELECT_REWARD_SLOTS);
             if (!rewardChoices.isEmpty() || canQuestsBeEdited()) {
                 gui.drawString(matrices, Translator.translatable("hqm.quest.pickOne"), START_X, REWARD_STR_Y + REWARD_Y_OFFSET, 0x404040);
-                drawRewards(gui, rewardChoices.toArray(), REWARD_Y + REWARD_Y_OFFSET, selectedReward, mX, mY, MAX_REWARD_SLOTS);
+                drawRewards(gui, rewardChoices.toList(), REWARD_Y + REWARD_Y_OFFSET, selectedReward, mX, mY, MAX_REWARD_SLOTS);
             }
         } else if (!rewardChoices.isEmpty()) {
             gui.drawString(matrices, Translator.translatable("hqm.quest.pickOneReward"), START_X, REWARD_STR_Y, 0x404040);
-            drawRewards(gui, rewardChoices.toArray(), REWARD_Y, selectedReward, mX, mY, MAX_REWARD_SLOTS);
+            drawRewards(gui, rewardChoices.toList(), REWARD_Y, selectedReward, mX, mY, MAX_REWARD_SLOTS);
         }
         
         for (LargeButton button : buttons) {
@@ -982,12 +983,12 @@ public class Quest {
         }
         
         if (!rewards.isEmpty() || canQuestsBeEdited()) {
-            drawRewardMouseOver(matrices, gui, rewards.toArray(), REWARD_Y, -1, mX, mY);
+            drawRewardMouseOver(matrices, gui, rewards.toList(), REWARD_Y, -1, mX, mY);
             if (!rewardChoices.isEmpty() || canQuestsBeEdited()) {
-                drawRewardMouseOver(matrices, gui, rewardChoices.toArray(), REWARD_Y + REWARD_Y_OFFSET, selectedReward, mX, mY);
+                drawRewardMouseOver(matrices, gui, rewardChoices.toList(), REWARD_Y + REWARD_Y_OFFSET, selectedReward, mX, mY);
             }
         } else if (!rewardChoices.isEmpty()) {
-            drawRewardMouseOver(matrices, gui, rewardChoices.toArray(), REWARD_Y, selectedReward, mX, mY);
+            drawRewardMouseOver(matrices, gui, rewardChoices.toList(), REWARD_Y, selectedReward, mX, mY);
         }
         for (LargeButton button : buttons) {
             button.renderTooltip(matrices, gui, player, mX, mY);
@@ -1037,23 +1038,23 @@ public class Quest {
     }
     
     @Environment(EnvType.CLIENT)
-    private void drawRewards(GuiQuestBook gui, ItemStack[] rewards, int y, int selected, int mX, int mY, int max) {
+    private void drawRewards(GuiQuestBook gui, NonNullList<ItemStack> rewards, int y, int selected, int mX, int mY, int max) {
         rewards = getEditFriendlyRewards(rewards, max);
         
         
-        for (int i = 0; i < rewards.length; i++) {
-            gui.drawItemStack(rewards[i], START_X + i * REWARD_OFFSET, y, mX, mY, selected == i);
+        for (int i = 0; i < rewards.size(); i++) {
+            gui.drawItemStack(rewards.get(i), START_X + i * REWARD_OFFSET, y, mX, mY, selected == i);
         }
     }
     
     @Environment(EnvType.CLIENT)
-    private void drawRewardMouseOver(PoseStack matrices, GuiQuestBook gui, ItemStack[] rewards, int y, int selected, int mX, int mY) {
+    private void drawRewardMouseOver(PoseStack matrices, GuiQuestBook gui, NonNullList<ItemStack> rewards, int y, int selected, int mX, int mY) {
         if (rewards != null) {
-            for (int i = 0; i < rewards.length; i++) {
+            for (int i = 0; i < rewards.size(); i++) {
                 if (gui.inBounds(START_X + i * REWARD_OFFSET, y, ITEM_SIZE, ITEM_SIZE, mX, mY)) {
-                    if (rewards[i] != null) {
-                        GuiQuestBook.setSelectedStack(rewards[i]);
-                        List<Component> str = rewards[i].getTooltipLines(Minecraft.getInstance().player, Minecraft.getInstance().options.advancedItemTooltips ? TooltipFlag.Default.ADVANCED : TooltipFlag.Default.NORMAL);
+                    if (rewards.get(i) != null) {
+                        GuiQuestBook.setSelectedStack(rewards.get(i));
+                        List<Component> str = rewards.get(i).getTooltipLines(Minecraft.getInstance().player, Minecraft.getInstance().options.advancedItemTooltips ? TooltipFlag.Default.ADVANCED : TooltipFlag.Default.NORMAL);
                         List<FormattedText> list2 = Lists.newArrayList(str);
                         if (selected == i) {
                             list2.add(FormattedText.EMPTY);
@@ -1068,25 +1069,26 @@ public class Quest {
     }
     
     @Environment(EnvType.CLIENT)
-    private ItemStack[] getEditFriendlyRewards(ItemStack[] rewards, int max) {
-        if (rewards == null) {
-            return new ItemStack[]{ItemStack.EMPTY};
-        } else if (canQuestsBeEdited() && rewards.length < max) {
-            ItemStack[] ret = Arrays.copyOf(rewards, rewards.length + 1);
-            ret[ret.length - 1] = ItemStack.EMPTY;
-            return ret;
+    private NonNullList<ItemStack> getEditFriendlyRewards(NonNullList<ItemStack> rewards, int max) {
+        if (rewards.isEmpty()) {
+            return NonNullList.withSize(1, ItemStack.EMPTY);
+        } else if (canQuestsBeEdited() && rewards.size() < max) {
+            NonNullList<ItemStack> rewardsWithEmpty = NonNullList.create();
+            rewardsWithEmpty.addAll(rewards);
+            rewardsWithEmpty.add(ItemStack.EMPTY);
+            return rewardsWithEmpty;
         } else {
             return rewards;
         }
     }
     
     @Environment(EnvType.CLIENT)
-    private void handleRewardClick(GuiQuestBook gui, Player player, ItemStack[] rawRewards, int y, boolean canSelect, int mX, int mY) {
-        ItemStack[] rewards = getEditFriendlyRewards(rawRewards, canSelect ? MAX_SELECT_REWARD_SLOTS : MAX_REWARD_SLOTS);
+    private void handleRewardClick(GuiQuestBook gui, Player player, NonNullList<ItemStack> rawRewards, int y, boolean canSelect, int mX, int mY) {
+        NonNullList<ItemStack> rewards = getEditFriendlyRewards(rawRewards, canSelect ? MAX_SELECT_REWARD_SLOTS : MAX_REWARD_SLOTS);
         
         boolean doubleClick = false;
         
-        for (int i = 0; i < rewards.length; i++) {
+        for (int i = 0; i < rewards.size(); i++) {
             if (gui.inBounds(START_X + i * REWARD_OFFSET, y, ITEM_SIZE, ITEM_SIZE, mX, mY)) {
                 if (gui.getCurrentMode() == EditMode.NORMAL) {
                     int lastDiff = player.tickCount - lastClicked;
@@ -1101,44 +1103,30 @@ public class Quest {
                 if (canSelect && (!canQuestsBeEdited() || (gui.getCurrentMode() == EditMode.NORMAL && !doubleClick))) {
                     if (selectedReward == i) {
                         selectedReward = -1;
-                    } else if (rewards[i] != null) {
+                    } else if (rewards.get(i) != null) {
                         selectedReward = i;
                     }
                 } else if (canQuestsBeEdited()) {
                     if (gui.getCurrentMode() == EditMode.DELETE) {
-                        if (rewards[i] != null) {
-                            ItemStack[] newRewards;
-                            if (rawRewards.length == 1) {
-                                newRewards = null;
-                                if (canSelect) {
+                        if (i < rawRewards.size()) {
+                            rawRewards.remove(i);
+                            if (canSelect && selectedReward != -1) {
+                                if (selectedReward == i) {
                                     selectedReward = -1;
-                                }
-                            } else {
-                                newRewards = new ItemStack[rawRewards.length - 1];
-                                int id = 0;
-                                for (int j = 0; j < rawRewards.length; j++) {
-                                    if (j != i) {
-                                        newRewards[id] = rawRewards[j];
-                                        id++;
-                                    }
-                                }
-                                if (canSelect && selectedReward != -1) {
-                                    if (selectedReward == i) {
-                                        selectedReward = -1;
-                                    } else if (selectedReward > i) {
-                                        selectedReward--;
-                                    }
+                                } else if (selectedReward > i) {
+                                    selectedReward--;
                                 }
                             }
+                            
                             if (canSelect) {
-                                this.rewardChoices.set(newRewards);
+                                this.rewardChoices.set(rawRewards);
                             } else {
-                                this.rewards.set(newRewards);
+                                this.rewards.set(rawRewards);
                             }
                             SaveHelper.add(SaveHelper.EditType.REWARD_REMOVE);
                         }
                     } else if (gui.getCurrentMode() == EditMode.ITEM || doubleClick) {
-                        gui.setEditMenu(new GuiEditMenuItem(gui, player, rewards[i], i, canSelect ? GuiEditMenuItem.Type.PICK_REWARD : GuiEditMenuItem.Type.REWARD, rewards[i] == null ? 1 : rewards[i].getCount(), ItemPrecision.PRECISE));
+                        gui.setEditMenu(new GuiEditMenuItem(gui, player, rewards.get(i), i, canSelect ? GuiEditMenuItem.Type.PICK_REWARD : GuiEditMenuItem.Type.REWARD, rewards.get(i) == null ? 1 : rewards.get(i).getCount(), ItemPrecision.PRECISE));
                     }
                 }
                 
@@ -1215,12 +1203,12 @@ public class Quest {
             }
             
             if (!rewards.isEmpty() || canQuestsBeEdited()) {
-                handleRewardClick(gui, player, rewards.toArray(), REWARD_Y, false, mX, mY);
+                handleRewardClick(gui, player, rewards.toList(), REWARD_Y, false, mX, mY);
                 if (!rewardChoices.isEmpty() || canQuestsBeEdited()) {
-                    handleRewardClick(gui, player, rewardChoices.toArray(), REWARD_Y + REWARD_Y_OFFSET, true, mX, mY);
+                    handleRewardClick(gui, player, rewardChoices.toList(), REWARD_Y + REWARD_Y_OFFSET, true, mX, mY);
                 }
             } else if (!rewardChoices.isEmpty()) {
-                handleRewardClick(gui, player, rewardChoices.toArray(), REWARD_Y, true, mX, mY);
+                handleRewardClick(gui, player, rewardChoices.toList(), REWARD_Y, true, mX, mY);
             }
             
             if (selectedTask != null) {
@@ -1334,7 +1322,7 @@ public class Quest {
             if (getQuestData(player).getReward(player) && (!rewards.isEmpty() || !rewardChoices.isEmpty())) {
                 List<ItemStack> items = new ArrayList<>();
                 if (!rewards.isEmpty()) {
-                    for (ItemStack stack : rewards.toArray()) {
+                    for (ItemStack stack : rewards.toList()) {
                         items.add(stack.copy());
                     }
                 }

--- a/common/src/main/java/hardcorequesting/common/quests/Quest.java
+++ b/common/src/main/java/hardcorequesting/common/quests/Quest.java
@@ -1052,7 +1052,7 @@ public class Quest {
         if (rewards != null) {
             for (int i = 0; i < rewards.size(); i++) {
                 if (gui.inBounds(START_X + i * REWARD_OFFSET, y, ITEM_SIZE, ITEM_SIZE, mX, mY)) {
-                    if (rewards.get(i) != null) {
+                    if (!rewards.get(i).isEmpty()) {
                         GuiQuestBook.setSelectedStack(rewards.get(i));
                         List<Component> str = rewards.get(i).getTooltipLines(Minecraft.getInstance().player, Minecraft.getInstance().options.advancedItemTooltips ? TooltipFlag.Default.ADVANCED : TooltipFlag.Default.NORMAL);
                         List<FormattedText> list2 = Lists.newArrayList(str);
@@ -1103,7 +1103,7 @@ public class Quest {
                 if (canSelect && (!canQuestsBeEdited() || (gui.getCurrentMode() == EditMode.NORMAL && !doubleClick))) {
                     if (selectedReward == i) {
                         selectedReward = -1;
-                    } else if (rewards.get(i) != null) {
+                    } else if (!rewards.get(i).isEmpty()) {
                         selectedReward = i;
                     }
                 } else if (canQuestsBeEdited()) {
@@ -1126,7 +1126,7 @@ public class Quest {
                             SaveHelper.add(SaveHelper.EditType.REWARD_REMOVE);
                         }
                     } else if (gui.getCurrentMode() == EditMode.ITEM || doubleClick) {
-                        gui.setEditMenu(new GuiEditMenuItem(gui, player, rewards.get(i), i, canSelect ? GuiEditMenuItem.Type.PICK_REWARD : GuiEditMenuItem.Type.REWARD, rewards.get(i) == null ? 1 : rewards.get(i).getCount(), ItemPrecision.PRECISE));
+                        gui.setEditMenu(new GuiEditMenuItem(gui, player, rewards.get(i), i, canSelect ? GuiEditMenuItem.Type.PICK_REWARD : GuiEditMenuItem.Type.REWARD, rewards.get(i).isEmpty() ? 1 : rewards.get(i).getCount(), ItemPrecision.PRECISE));
                     }
                 }
                 

--- a/common/src/main/java/hardcorequesting/common/quests/reward/ItemStackReward.java
+++ b/common/src/main/java/hardcorequesting/common/quests/reward/ItemStackReward.java
@@ -4,6 +4,6 @@ import net.minecraft.world.item.ItemStack;
 
 public class ItemStackReward extends QuestReward<ItemStack> {
     public ItemStackReward(ItemStack stack) {
-        super(stack);
+        super(stack != null ? stack : ItemStack.EMPTY);
     }
 }

--- a/common/src/main/java/hardcorequesting/common/quests/reward/ItemStackRewardList.java
+++ b/common/src/main/java/hardcorequesting/common/quests/reward/ItemStackRewardList.java
@@ -1,21 +1,18 @@
 package hardcorequesting.common.quests.reward;
 
+import net.minecraft.core.NonNullList;
 import net.minecraft.world.item.ItemStack;
-
-import java.util.ArrayList;
-import java.util.List;
 
 public class ItemStackRewardList extends QuestRewardList<ItemStack> {
     
-    public void addAll(ItemStack[] array) {
-        for (ItemStack stack : array)
+    public void addAll(NonNullList<ItemStack> list) {
+        for (ItemStack stack : list)
             add(new ItemStackReward(stack));
     }
     
-    public void set(ItemStack[] array) {
+    public void set(NonNullList<ItemStack> list) {
         clear();
-        if (array != null)
-            addAll(array);
+        addAll(list);
     }
     
     public void set(int id, ItemStack stack) {
@@ -26,15 +23,13 @@ public class ItemStackRewardList extends QuestRewardList<ItemStack> {
         add(new ItemStackReward(stack));
     }
     
-    @SuppressWarnings("ConstantConditions")
-    @Override
-    public ItemStack[] toArray() { // TODO change every ItemStack[] to NonNullList<ItemStack>
-        List<ItemStack> result = new ArrayList<>();
+    public NonNullList<ItemStack> toList() {
+        NonNullList<ItemStack> result = NonNullList.create();
         for (QuestReward<ItemStack> reward : list) {
-            if (reward.getReward() != null) {
+            if (!reward.getReward().isEmpty()) {
                 result.add(reward.getReward());
             }
         }
-        return result.isEmpty() ? null : result.toArray(new ItemStack[0]);
+        return result;
     }
 }


### PR DESCRIPTION
Changed `ItemStack` arrays (specifically those used for quest rewards) to non-null instances of `NonNullList<ItemStack>`, and changed some item stack null-checks to `itemStack.isEmpty()`.

Fixes #550.