### PR TITLE
Fix sidedness crash on fabric servers

### DIFF
--- a/common/src/main/java/hardcorequesting/common/proxies/ClientProxy.java
+++ b/common/src/main/java/hardcorequesting/common/proxies/ClientProxy.java
@@ -1,5 +1,6 @@
 package hardcorequesting.common.proxies;
 
+import hardcorequesting.common.HardcoreQuestingCore;
 import hardcorequesting.common.client.sounds.Sounds;
 import hardcorequesting.common.network.PacketContext;
 import hardcorequesting.common.quests.Quest;
@@ -16,7 +17,8 @@ public class ClientProxy extends CommonProxy {
     @Override
     public void init() {
         super.init();
-        Quest.clientTicker = QuestTicker.initClientTicker();
+        Quest.clientTicker = new QuestTicker();
+        HardcoreQuestingCore.platform.registerOnClientTick(minecraftClient -> Quest.clientTicker.tick(minecraftClient.level, true));
     }
     
     @Override

--- a/common/src/main/java/hardcorequesting/common/proxies/CommonProxy.java
+++ b/common/src/main/java/hardcorequesting/common/proxies/CommonProxy.java
@@ -1,5 +1,6 @@
 package hardcorequesting.common.proxies;
 
+import hardcorequesting.common.HardcoreQuestingCore;
 import hardcorequesting.common.network.PacketContext;
 import hardcorequesting.common.quests.Quest;
 import hardcorequesting.common.quests.QuestTicker;
@@ -9,7 +10,8 @@ public class CommonProxy {
     public void initSounds() {}
     
     public void init() {
-        Quest.serverTicker = QuestTicker.initServerTicker();
+        Quest.serverTicker = new QuestTicker();
+        HardcoreQuestingCore.platform.registerOnServerTick(minecraftServer -> Quest.serverTicker.tick(minecraftServer.overworld(), false));
     }
     
     public boolean isClient() {

--- a/common/src/main/java/hardcorequesting/common/quests/QuestTicker.java
+++ b/common/src/main/java/hardcorequesting/common/quests/QuestTicker.java
@@ -1,28 +1,12 @@
 package hardcorequesting.common.quests;
 
-import hardcorequesting.common.HardcoreQuestingCore;
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.minecraft.world.level.Level;
 
 public class QuestTicker {
     
     private long hours;
     
-    @Environment(EnvType.CLIENT)
-    public static QuestTicker initClientTicker() {
-        QuestTicker ticker = new QuestTicker();
-        HardcoreQuestingCore.platform.registerOnClientTick(minecraftClient -> ticker.tick(minecraftClient.level, true));
-        return ticker;
-    }
-    
-    public static QuestTicker initServerTicker() {
-        QuestTicker ticker = new QuestTicker();
-        HardcoreQuestingCore.platform.registerOnServerTick(minecraftServer -> ticker.tick(minecraftServer.overworld(), false));
-        return ticker;
-    }
-    
-    private QuestTicker() {}
+    public QuestTicker() {}
     
     public void tick(Level level, boolean isClient) {
         if (level != null && level.getGameTime() / 1000 != hours) {


### PR DESCRIPTION
Seems like the fix in #557 didn't work for fabric servers. Guessing that it has to do with how the two platforms handle lambdas in classloading. For that reason, I moved the tick event registering to the two proxies, which seemed to fix the issue.
Closes #566