### PR TITLE
Command reward fixes

### DIFF
--- a/common/src/main/java/hardcorequesting/common/quests/reward/CommandReward.java
+++ b/common/src/main/java/hardcorequesting/common/quests/reward/CommandReward.java
@@ -4,23 +4,21 @@ import net.minecraft.world.entity.player.Player;
 
 public class CommandReward extends QuestReward<CommandReward.Command> {
     
+    private static final int PERMISSION_LEVEL = 2;
+    
     public CommandReward(Command command) {
         super(command);
     }
     
-    public void execute(Player player) {
-        getReward().execute(player);
-    }
-    
     public static class Command {
-        private String commandString;
+        private final String commandString;
         
         public Command(String commandString) {
             this.commandString = commandString;
         }
         
         public void execute(Player player) {
-            player.getServer().getCommands().performCommand(player.createCommandSourceStack(), commandString.replaceAll("@p", player.getScoreboardName()));
+            player.getServer().getCommands().performCommand(player.createCommandSourceStack().withPermission(PERMISSION_LEVEL), commandString);
         }
         
         public String asString() {

--- a/common/src/main/java/hardcorequesting/common/quests/reward/CommandReward.java
+++ b/common/src/main/java/hardcorequesting/common/quests/reward/CommandReward.java
@@ -3,6 +3,7 @@ package hardcorequesting.common.quests.reward;
 import net.minecraft.commands.CommandSource;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.TextComponent;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.player.Player;
 
@@ -10,6 +11,7 @@ import java.util.UUID;
 
 public class CommandReward extends QuestReward<CommandReward.Command> {
     
+    private static final String NAME = "Mod-HQM";
     private static final int PERMISSION_LEVEL = 2;
     
     public CommandReward(Command command) {
@@ -25,7 +27,7 @@ public class CommandReward extends QuestReward<CommandReward.Command> {
         
         public void execute(Player player) {
             CommandSourceStack sourceStack = new CommandSourceStack(new WrapperCommandSource(player), player.position(), player.getRotationVector(),
-                    player.level instanceof ServerLevel ? (ServerLevel)player.level : null, PERMISSION_LEVEL, player.getName().getString(), player.getDisplayName(), player.level.getServer(), player);
+                    player.level instanceof ServerLevel ? (ServerLevel)player.level : null, PERMISSION_LEVEL, NAME, new TextComponent(NAME), player.level.getServer(), player);
             player.getServer().getCommands().performCommand(sourceStack, commandString);
         }
         

--- a/common/src/main/java/hardcorequesting/common/quests/reward/CommandReward.java
+++ b/common/src/main/java/hardcorequesting/common/quests/reward/CommandReward.java
@@ -1,6 +1,12 @@
 package hardcorequesting.common.quests.reward;
 
+import net.minecraft.commands.CommandSource;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.player.Player;
+
+import java.util.UUID;
 
 public class CommandReward extends QuestReward<CommandReward.Command> {
     
@@ -18,11 +24,41 @@ public class CommandReward extends QuestReward<CommandReward.Command> {
         }
         
         public void execute(Player player) {
-            player.getServer().getCommands().performCommand(player.createCommandSourceStack().withPermission(PERMISSION_LEVEL), commandString);
+            CommandSourceStack sourceStack = new CommandSourceStack(new WrapperCommandSource(player), player.position(), player.getRotationVector(),
+                    player.level instanceof ServerLevel ? (ServerLevel)player.level : null, PERMISSION_LEVEL, player.getName().getString(), player.getDisplayName(), player.level.getServer(), player);
+            player.getServer().getCommands().performCommand(sourceStack, commandString);
         }
         
         public String asString() {
             return this.commandString;
+        }
+    }
+    
+    private static class WrapperCommandSource implements CommandSource {
+        private final Player player;
+    
+        private WrapperCommandSource(Player player) {
+            this.player = player;
+        }
+    
+        @Override
+        public void sendMessage(Component component, UUID uuid) {
+        player.sendMessage(component, uuid);
+        }
+    
+        @Override
+        public boolean acceptsSuccess() {
+            return false;
+        }
+    
+        @Override
+        public boolean acceptsFailure() {
+            return true;
+        }
+    
+        @Override
+        public boolean shouldInformAdmins() {
+            return true;
         }
     }
 }


### PR DESCRIPTION
- Execution of command rewards now have permission level fixed at 2
- Command rewards no longer send command success messages to the receiving player
- Command rewards now use "Mod-HQM" as command source name
Closes #560.