### PR TITLE
Rendering fixes

### DIFF
--- a/common/src/main/java/hardcorequesting/common/client/interfaces/GuiBase.java
+++ b/common/src/main/java/hardcorequesting/common/client/interfaces/GuiBase.java
@@ -124,14 +124,16 @@ public class GuiBase extends Screen {
                 break;
         }
         
-        BufferBuilder bufferBuilder = Tesselator.getInstance().getBuilder();
+        RenderSystem.setShader(GameRenderer::getPositionTexShader);
+        
+        Tesselator tesselator = Tesselator.getInstance();
+        BufferBuilder bufferBuilder = tesselator.getBuilder();
         bufferBuilder.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_TEX);
         bufferBuilder.vertex(x, y + targetH, this.getBlitOffset()).uv((float) pt1[0], (float) pt1[1]).endVertex();
         bufferBuilder.vertex(x + targetW, y + targetH, this.getBlitOffset()).uv((float) pt2[0], (float) pt2[1]).endVertex();
         bufferBuilder.vertex(x + targetW, y, this.getBlitOffset()).uv((float) pt3[0], (float) pt3[1]).endVertex();
         bufferBuilder.vertex(x, y, this.getBlitOffset()).uv((float) pt4[0], (float) pt4[1]).endVertex();
-        bufferBuilder.end();
-        BufferUploader.end(bufferBuilder);
+        tesselator.end();
     }
     
     public void renderTooltip(PoseStack matrices, FormattedText stringRenderable, int x, int y) {
@@ -182,30 +184,6 @@ public class GuiBase extends Screen {
     
     public void drawFluid(FluidStack fluid, PoseStack stack, int x, int y) {
         HardcoreQuestingCore.platform.renderFluidStack(fluid, stack, getLeft() + x, getTop() + y, getLeft() + x + 16, getTop() + y + 16);
-        /*//IIcon icon = fluid.getIconStack();
-        Item stack = null;
-
-        if (icon == null) {
-            if (FluidRegistry.WATER.equals(fluid)) {
-                icon = Blocks.water.getIconStack(0, 0);
-            } else if (FluidRegistry.LAVA.equals(fluid)) {
-                icon = Blocks.water.getIconStack(0, 0);
-            }
-        }
-
-        if (icon != null) {
-            GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
-
-            ResourceHelper.bindResource(MAP_TEXTURE);
-
-            drawRect(x, y, 256 - 16, 256 - 16, 16, 16);
-
-            ResourceHelper.bindResource(TERRAIN);
-            setColor(fluid.getColor());
-            drawIcon(icon, x, y);
-
-            GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
-        }*/
     }
     
     public void applyColor(int color) {

--- a/common/src/main/java/hardcorequesting/common/client/interfaces/GuiBase.java
+++ b/common/src/main/java/hardcorequesting/common/client/interfaces/GuiBase.java
@@ -155,7 +155,8 @@ public class GuiBase extends Screen {
         applyColor(color);
         RenderSystem.setShader(GameRenderer::getRendertypeLinesShader);
         RenderSystem.disableTexture();
-        RenderSystem.lineWidth(1 + thickness * this.width / 500F);
+        float scale = (float) this.minecraft.getWindow().getGuiScale();
+        RenderSystem.lineWidth(1 + thickness * scale / 2F);
     
         Tesselator tesselator = Tesselator.getInstance();
         BufferBuilder builder = tesselator.getBuilder();

--- a/common/src/main/java/hardcorequesting/common/client/interfaces/ResourceHelper.java
+++ b/common/src/main/java/hardcorequesting/common/client/interfaces/ResourceHelper.java
@@ -3,7 +3,6 @@ package hardcorequesting.common.client.interfaces;
 import com.mojang.blaze3d.systems.RenderSystem;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
-import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.resources.ResourceLocation;
 
 @Environment(EnvType.CLIENT)
@@ -17,8 +16,6 @@ public abstract class ResourceHelper {
     }
     
     public static void bindResource(ResourceLocation resource) {
-        RenderSystem.setShader(GameRenderer::getPositionTexShader);
-        RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
         RenderSystem.setShaderTexture(0, resource);
     }
     


### PR DESCRIPTION
- Updates drawLine() to use minecrafts rendering system (fixes #582)
- Tweaks how the size of lines scale (previously they scaled with the scaled width, which I thought was bad)
- Remove mistaken color clear and relocated a setShader() call (that were both added in #580)