### PR TITLE
Quest data and quest reward cleanup

### DIFF
--- a/common/src/main/java/hardcorequesting/common/bag/Group.java
+++ b/common/src/main/java/hardcorequesting/common/bag/Group.java
@@ -7,9 +7,9 @@ import hardcorequesting.common.client.interfaces.GuiQuestBook;
 import hardcorequesting.common.client.interfaces.ScrollBar;
 import hardcorequesting.common.client.interfaces.edit.PickItemMenu;
 import hardcorequesting.common.client.interfaces.edit.TextMenu;
-import hardcorequesting.common.quests.Quest;
 import hardcorequesting.common.quests.QuestLine;
 import hardcorequesting.common.quests.QuestingDataManager;
+import hardcorequesting.common.quests.reward.QuestRewards;
 import hardcorequesting.common.util.EditType;
 import hardcorequesting.common.util.SaveHelper;
 import hardcorequesting.common.util.Translator;
@@ -212,7 +212,7 @@ public class Group {
         
         List<ItemStack> itemsToAdd = items.stream().map(ItemStack::copy).collect(Collectors.toList());
         
-        Quest.addItems(player, itemsToAdd);
+        QuestRewards.addItems(player, itemsToAdd);
         
         itemsToAdd.stream().filter(item -> item.getCount() > 0).forEach(item -> {
             ItemEntity entityItem = new ItemEntity(player.getCommandSenderWorld(), player.getX() + 0.5D, player.getY() + 0.5D, player.getZ() + 0.5D, item);

--- a/common/src/main/java/hardcorequesting/common/client/ClientChange.java
+++ b/common/src/main/java/hardcorequesting/common/client/ClientChange.java
@@ -96,7 +96,7 @@ public enum ClientChange {
             JsonObject root = parser.parse(data).getAsJsonObject();
             Quest quest = Quest.getQuest(UUID.fromString(root.get(QUEST).getAsString()));
             if (quest != null)
-                quest.claimReward(player, root.get(REWARD).getAsInt());
+                quest.getRewards().claimReward(player, root.get(REWARD).getAsInt());
         }
     }),
     TRACKER_UPDATE(new ClientUpdater<TrackerBlockEntity>() {

--- a/common/src/main/java/hardcorequesting/common/client/interfaces/edit/GuiEditMenuCommandEditor.java
+++ b/common/src/main/java/hardcorequesting/common/client/interfaces/edit/GuiEditMenuCommandEditor.java
@@ -28,7 +28,7 @@ public class GuiEditMenuCommandEditor extends TextMenu {
     public GuiEditMenuCommandEditor(GuiQuestBook gui, Player player) {
         super(gui, player, "", false, -1, null);
         this.quest = GuiQuestBook.selectedQuest;
-        this.commands = this.quest.getCommandRewardsAsStrings();
+        this.commands = this.quest.getRewards().getCommandRewardsAsStrings();
         this.edited = new boolean[this.commands.length];
         this.id = -1;
         if (gui.getCurrentMode() == EditMode.COMMAND_CHANGE) {
@@ -68,17 +68,17 @@ public class GuiEditMenuCommandEditor extends TextMenu {
         }
         
         if (this.added != null && !this.added.isEmpty()) {
-            quest.addCommand(this.added);
+            quest.getRewards().addCommand(this.added);
             SaveHelper.add(EditType.COMMAND_ADD);
         }
         if (this.commands != null) {
             for (int i = this.commands.length - 1; i >= 0; i--) {
                 if (edited[i]) {
                     if (commands[i].isEmpty()) {
-                        quest.removeCommand(i);
+                        quest.getRewards().removeCommand(i);
                         SaveHelper.add(EditType.COMMAND_REMOVE);
                     } else {
-                        quest.editCommand(i, this.commands[i]);
+                        quest.getRewards().editCommand(i, this.commands[i]);
                         SaveHelper.add(EditType.COMMAND_CHANGE);
                     }
                 }

--- a/common/src/main/java/hardcorequesting/common/client/interfaces/edit/GuiEditMenuReputationReward.java
+++ b/common/src/main/java/hardcorequesting/common/client/interfaces/edit/GuiEditMenuReputationReward.java
@@ -172,7 +172,7 @@ public class GuiEditMenuReputationReward extends GuiEditMenuExtended {
     
     @Override
     public void save(GuiBase gui) {
-        GuiQuestBook.selectedQuest.setReputationRewards(rewards.isEmpty() ? null : rewards);
+        GuiQuestBook.selectedQuest.getRewards().setReputationRewards(rewards.isEmpty() ? null : rewards);
         SaveHelper.add(EditType.REPUTATION_REWARD_CHANGE);
     }
 }

--- a/common/src/main/java/hardcorequesting/common/io/adapter/QuestDataAdapter.java
+++ b/common/src/main/java/hardcorequesting/common/io/adapter/QuestDataAdapter.java
@@ -15,7 +15,6 @@ import java.util.List;
 public class QuestDataAdapter {
     
     public static final TypeAdapter<QuestData> QUEST_DATA_ADAPTER = new TypeAdapter<>() {
-        public static final String PLAYERS = "players";
         public static final String REWARDS = "rewards";
         public static final String COMPLETED = "completed";
         public static final String CLAIMED = "claimed";
@@ -26,10 +25,9 @@ public class QuestDataAdapter {
         @Override
         public void write(JsonWriter out, QuestData value) throws IOException {
             out.beginObject();
-            out.name(PLAYERS).value(value.getPlayers());
             out.name(REWARDS).beginArray();
-            for (int i = 0; i < value.getPlayers(); i++)
-                out.value(value.canClaimReward(i));
+            for (boolean canClaim : value.getRewardsForSerialization())
+                out.value(canClaim);
             out.endArray();
             out.name(COMPLETED).value(value.completed);
             out.name(CLAIMED).value(value.claimed);
@@ -47,18 +45,16 @@ public class QuestDataAdapter {
         
         @Override
         public QuestData read(JsonReader in) throws IOException {
-            QuestData data = new QuestData(1);
+            QuestData data = new QuestData();
             in.beginObject();
             while (in.hasNext()) {
                 switch (in.nextName()) {
-                    case PLAYERS:
-                        data = new QuestData(in.nextInt());
-                        break;
                     case REWARDS:
                         in.beginArray();
-                        int i = 0;
-                        while (in.hasNext() && i < data.getPlayers())
-                            data.setCanClaimReward(i++, in.nextBoolean());
+                        List<Boolean> claimableRewards = new ArrayList<>();
+                        while (in.hasNext())
+                            claimableRewards.add(in.nextBoolean());
+                        data.setRewardsFromSerialization(claimableRewards);
                         in.endArray();
                         break;
                     case COMPLETED:

--- a/common/src/main/java/hardcorequesting/common/io/adapter/QuestDataAdapter.java
+++ b/common/src/main/java/hardcorequesting/common/io/adapter/QuestDataAdapter.java
@@ -75,7 +75,6 @@ public class QuestDataAdapter {
                         break;
                     case TASKS_SIZE:
                         taskSize = in.nextInt();
-                        data.clearTaskDataWithSize(taskSize);
                         break;
                     case TASKS:
                         in.beginArray();

--- a/common/src/main/java/hardcorequesting/common/io/adapter/QuestDataAdapter.java
+++ b/common/src/main/java/hardcorequesting/common/io/adapter/QuestDataAdapter.java
@@ -26,10 +26,10 @@ public class QuestDataAdapter {
         @Override
         public void write(JsonWriter out, QuestData value) throws IOException {
             out.beginObject();
-            out.name(PLAYERS).value(value.reward.length);
+            out.name(PLAYERS).value(value.getPlayers());
             out.name(REWARDS).beginArray();
-            for (boolean bool : value.reward)
-                out.value(bool);
+            for (int i = 0; i < value.getPlayers(); i++)
+                out.value(value.canClaimReward(i));
             out.endArray();
             out.name(COMPLETED).value(value.completed);
             out.name(CLAIMED).value(value.claimed);
@@ -57,8 +57,8 @@ public class QuestDataAdapter {
                     case REWARDS:
                         in.beginArray();
                         int i = 0;
-                        while (in.hasNext() && i < data.reward.length)
-                            data.reward[i++] = in.nextBoolean();
+                        while (in.hasNext() && i < data.getPlayers())
+                            data.setCanClaimReward(i++, in.nextBoolean());
                         in.endArray();
                         break;
                     case COMPLETED:

--- a/common/src/main/java/hardcorequesting/common/io/adapter/QuestDataAdapter.java
+++ b/common/src/main/java/hardcorequesting/common/io/adapter/QuestDataAdapter.java
@@ -15,10 +15,12 @@ import java.util.List;
 public class QuestDataAdapter {
     
     public static final TypeAdapter<QuestData> QUEST_DATA_ADAPTER = new TypeAdapter<>() {
+        public static final String PLAYERS = "players";
         public static final String REWARDS = "rewards";
         public static final String COMPLETED = "completed";
         public static final String CLAIMED = "claimed";
         public static final String TASKS = "tasks";
+        public static final String TASKS_SIZE = "tasksSize";
         public static final String AVAILABLE = "available";
         public static final String TIME = "time";
         
@@ -49,6 +51,10 @@ public class QuestDataAdapter {
             in.beginObject();
             while (in.hasNext()) {
                 switch (in.nextName()) {
+                    case PLAYERS:
+                    case TASKS_SIZE:
+                        in.nextInt();   //Sizes are no longer used. Read it for backwards-compatibility
+                        break;
                     case REWARDS:
                         in.beginArray();
                         List<Boolean> claimableRewards = new ArrayList<>();

--- a/common/src/main/java/hardcorequesting/common/io/adapter/QuestDataAdapter.java
+++ b/common/src/main/java/hardcorequesting/common/io/adapter/QuestDataAdapter.java
@@ -32,11 +32,13 @@ public class QuestDataAdapter {
             out.name(CLAIMED).value(value.claimed);
             out.name(AVAILABLE).value(value.available);
             out.name(TIME).value(value.time);
-            out.name(TASKS_SIZE).value(value.tasks.length);
+            out.name(TASKS_SIZE).value(value.getTaskSize());
             out.name(TASKS).beginArray();
-            for (TaskData task : value.tasks)
-                if (task != null)
-                    QuestTaskAdapter.QUEST_DATA_TASK_ADAPTER.write(out, task);
+            for (int i = 0; i < value.getTaskSize(); i++) {
+                TaskData data = value.getTaskData(i);
+                if (data != null)
+                    QuestTaskAdapter.QUEST_DATA_TASK_ADAPTER.write(out, data);
+            }
             out.endArray();
             out.endObject();
         }
@@ -46,6 +48,7 @@ public class QuestDataAdapter {
             QuestData data = new QuestData(1);
             in.beginObject();
             int i;
+            int taskSize = 0;
             while (in.hasNext()) {
                 switch (in.nextName()) {
                     case PLAYERS:
@@ -71,13 +74,14 @@ public class QuestDataAdapter {
                         data.time = in.nextLong();
                         break;
                     case TASKS_SIZE:
-                        data.tasks = new TaskData[in.nextInt()];
+                        taskSize = in.nextInt();
+                        data.clearTaskDataWithSize(taskSize);
                         break;
                     case TASKS:
                         in.beginArray();
                         i = 0;
-                        while (in.hasNext() && i < data.tasks.length)
-                            data.tasks[i++] = QuestTaskAdapter.QUEST_DATA_TASK_ADAPTER.read(in);
+                        while (in.hasNext() && i < taskSize)
+                            data.setTaskData(i++, QuestTaskAdapter.QUEST_DATA_TASK_ADAPTER.read(in));
                         in.endArray();
                         break;
                     default:

--- a/common/src/main/java/hardcorequesting/common/io/adapter/QuestDataAdapter.java
+++ b/common/src/main/java/hardcorequesting/common/io/adapter/QuestDataAdapter.java
@@ -32,7 +32,7 @@ public class QuestDataAdapter {
                 out.value(canClaim);
             out.endArray();
             out.name(COMPLETED).value(value.completed);
-            out.name(CLAIMED).value(value.claimed);
+            out.name(CLAIMED).value(value.teamRewardClaimed);
             out.name(AVAILABLE).value(value.available);
             out.name(TIME).value(value.time);
             out.name(TASKS).beginArray();
@@ -67,7 +67,7 @@ public class QuestDataAdapter {
                         data.completed = in.nextBoolean();
                         break;
                     case CLAIMED:
-                        data.claimed = in.nextBoolean();
+                        data.teamRewardClaimed = in.nextBoolean();
                         break;
                     case AVAILABLE:
                         data.available = in.nextBoolean();

--- a/common/src/main/java/hardcorequesting/common/quests/Quest.java
+++ b/common/src/main/java/hardcorequesting/common/quests/Quest.java
@@ -991,7 +991,7 @@ public class Quest {
     }
     
     public boolean hasReward(Player player) {
-        return (getQuestData(player).getReward(player) && (!rewards.isEmpty() || !rewardChoices.isEmpty())) || (getQuestData(player).canClaim() && (reputationRewards != null || !commandRewardList.isEmpty()));
+        return (getQuestData(player).canClaimReward(player) && (!rewards.isEmpty() || !rewardChoices.isEmpty())) || (getQuestData(player).canClaim() && (reputationRewards != null || !commandRewardList.isEmpty()));
     }
     
     @Environment(EnvType.CLIENT)
@@ -1227,10 +1227,6 @@ public class Quest {
         return data;
     }
     
-    public void initRewards(int players, QuestData data) {
-        data.reward = new boolean[players];
-    }
-    
     public List<QuestTask<?>> getTasks() {
         return tasks;
     }
@@ -1266,7 +1262,7 @@ public class Quest {
     public void claimReward(Player player, int selectedReward) {
         if (hasReward(player)) {
             boolean sentInfo = false;
-            if (getQuestData(player).getReward(player) && (!rewards.isEmpty() || !rewardChoices.isEmpty())) {
+            if (getQuestData(player).canClaimReward(player) && (!rewards.isEmpty() || !rewardChoices.isEmpty())) {
                 List<ItemStack> items = new ArrayList<>();
                 if (!rewards.isEmpty()) {
                     for (ItemStack stack : rewards.toList()) {
@@ -1332,7 +1328,7 @@ public class Quest {
                     QuestData data = getQuestData(player);
                     Team team = QuestingDataManager.getInstance().getQuestingData(player).getTeam();
                     if (!team.isSingle() && team.getRewardSetting() == RewardSetting.ANY) {
-                        Arrays.fill(data.reward, false);
+                        data.claimFullReward();
                         sendUpdatedDataToTeam(player);
                     } else {
                         data.claimReward(player);

--- a/common/src/main/java/hardcorequesting/common/quests/Quest.java
+++ b/common/src/main/java/hardcorequesting/common/quests/Quest.java
@@ -1108,7 +1108,7 @@ public class Quest {
             int start = taskScroll.isVisible(gui) ? Math.round((getVisibleTasks(gui) - VISIBLE_TASKS) * taskScroll.getScroll()) : 0;
             int end = Math.min(start + VISIBLE_TASKS, tasks.size());
             for (int i = start; i < end; i++) {
-                QuestTask task = tasks.get(i);
+                QuestTask<?> task = tasks.get(i);
                 if (task.isVisible(player) || canQuestsBeEdited()) {
                     if (gui.inBounds(START_X, getTaskY(gui, id), gui.getStringWidth(task.getDescription()), TEXT_HEIGHT, mX, mY)) {
                         if (gui.isOpBook && Screen.hasShiftDown()) {
@@ -1138,11 +1138,11 @@ public class Quest {
                                 
                                 tasks.remove(i);
                                 nextTaskId = 0;
-                                for (QuestTask questTask : tasks) {
+                                for (QuestTask<?> questTask : tasks) {
                                     questTask.updateId();
                                 }
-                                
-                                addTaskData(getQuestData(player));
+    
+                                getQuestData(player).clearTaskData(this);
                                 SaveHelper.add(EditType.TASK_REMOVE);
                             }
                         } else if (task == selectedTask) {
@@ -1223,19 +1223,8 @@ public class Quest {
     
     public QuestData createData(int players) {
         QuestData data = new QuestData(players);
-        if (!addTaskData(data)) {
-            return null;
-        }
+        data.verifyTasksSize(this);
         return data;
-    }
-    
-    public boolean addTaskData(QuestData data) {
-        data.clearTaskData();
-        for (int i = 0; i < tasks.size(); i++) {
-            data.setTaskData(i, tasks.get(i).newQuestData());
-        }
-        
-        return true;
     }
     
     public void initRewards(int players, QuestData data) {
@@ -1479,7 +1468,7 @@ public class Quest {
     
     public void reset(QuestData data) {
         data.available = true;
-        addTaskData(data);
+        data.clearTaskData(this);
     }
     
     public void resetAll() {

--- a/common/src/main/java/hardcorequesting/common/quests/Quest.java
+++ b/common/src/main/java/hardcorequesting/common/quests/Quest.java
@@ -20,7 +20,6 @@ import hardcorequesting.common.network.IMessage;
 import hardcorequesting.common.network.NetworkManager;
 import hardcorequesting.common.network.message.QuestDataUpdateMessage;
 import hardcorequesting.common.quests.data.QuestData;
-import hardcorequesting.common.quests.data.TaskData;
 import hardcorequesting.common.quests.reward.CommandRewardList;
 import hardcorequesting.common.quests.reward.ItemStackRewardList;
 import hardcorequesting.common.quests.reward.ReputationReward;
@@ -1231,9 +1230,9 @@ public class Quest {
     }
     
     public boolean addTaskData(QuestData data) {
-        data.tasks = new TaskData[tasks.size()];
+        data.clearTaskDataWithSize(tasks.size());
         for (int i = 0; i < tasks.size(); i++) {
-            data.tasks[i] = tasks.get(i).newQuestData();
+            data.setTaskData(i, tasks.get(i).newQuestData());
         }
         
         return true;
@@ -1451,10 +1450,9 @@ public class Quest {
                 own.available = true;
             }
         }
-        
-        
-        for (int i = 0; i < own.tasks.length; i++) {
-            QuestTask<?> task = tasks.get(i);
+    
+    
+        for (QuestTask<?> task : tasks) {
             task.mergeProgress(playerId, own, other);
         }
     }
@@ -1462,9 +1460,8 @@ public class Quest {
     public void copyProgress(QuestData own, QuestData other) {
         own.completed = other.completed;
         own.available = other.available;
-        
-        for (int i = 0; i < own.tasks.length; i++) {
-            QuestTask<?> task = tasks.get(i);
+    
+        for (QuestTask<?> task : tasks) {
             task.copyProgress(own, other);
         }
     }

--- a/common/src/main/java/hardcorequesting/common/quests/Quest.java
+++ b/common/src/main/java/hardcorequesting/common/quests/Quest.java
@@ -1003,7 +1003,7 @@ public class Quest {
             own.completed = true;
             
             //If a quest is marked both claimed & available, then repeatable quests will never reset.
-            if (other.available && !own.claimed) {
+            if (other.available && !own.teamRewardClaimed) {
                 own.available = true;
             }
         }

--- a/common/src/main/java/hardcorequesting/common/quests/Quest.java
+++ b/common/src/main/java/hardcorequesting/common/quests/Quest.java
@@ -1230,7 +1230,7 @@ public class Quest {
     }
     
     public boolean addTaskData(QuestData data) {
-        data.clearTaskDataWithSize(tasks.size());
+        data.clearTaskData();
         for (int i = 0; i < tasks.size(); i++) {
             data.setTaskData(i, tasks.get(i).newQuestData());
         }

--- a/common/src/main/java/hardcorequesting/common/quests/data/QuestData.java
+++ b/common/src/main/java/hardcorequesting/common/quests/data/QuestData.java
@@ -17,10 +17,10 @@ import java.util.function.Supplier;
 public class QuestData {
     private static final Logger LOGGER = LogManager.getLogger();
     
-    private final List<Boolean> reward = new ArrayList<>();
+    private final List<Boolean> claimableRewards = new ArrayList<>();
+    private final List<TaskData> taskData = new ArrayList<>();
     public boolean completed;
     public boolean claimed;
-    private final List<TaskData> tasks = new ArrayList<>();
     public boolean available = true;
     public long time;
     
@@ -33,68 +33,68 @@ public class QuestData {
     public QuestData() {}
     
     public void setRewardsFromSerialization(List<Boolean> claimableRewards) {
-        reward.clear();
-        reward.addAll(claimableRewards);
+        this.claimableRewards.clear();
+        this.claimableRewards.addAll(claimableRewards);
     }
     
     public Iterable<Boolean> getRewardsForSerialization() {
-        return reward;
+        return claimableRewards;
     }
     
     public void setTaskDataFromSerialization(List<TaskData> taskData) {
-        tasks.clear();
-        tasks.addAll(taskData);
+        this.taskData.clear();
+        this.taskData.addAll(taskData);
     }
     
     public Iterable<TaskData> getTaskDataForSerialization() {
-        return tasks;
+        return taskData;
     }
     
     public void clearRewardClaims(int players) {
-        reward.clear();
+        claimableRewards.clear();
         for (int i = 0; i < players; i++)
-            reward.add(false);
+            claimableRewards.add(false);
     }
     
     public boolean canClaimReward(int playerId) {
-        return reward.get(playerId);
+        return claimableRewards.get(playerId);
     }
     
     public void setCanClaimReward(int playerId, boolean canClaim) {
-        reward.set(playerId, canClaim);
+        claimableRewards.set(playerId, canClaim);
     }
     
     public void removePlayer(int playerId) {
-        reward.remove(playerId);
+        claimableRewards.remove(playerId);
     }
     
     public void insertPlayer(int playerId, boolean canClaim) {
-        reward.add(playerId, canClaim);
+        claimableRewards.add(playerId, canClaim);
     }
     
     public boolean canClaimReward(Player player) {
         int id = getId(player);
-        return (id >= 0 && id < reward.size()) && reward.get(id);
+        return (id >= 0 && id < claimableRewards.size()) && claimableRewards.get(id);
     }
     
     public void claimReward(Player player) {
         int id = getId(player);
-        if (id >= 0 && id < reward.size()) {
-            reward.set(id, false);
+        if (id >= 0 && id < claimableRewards.size()) {
+            claimableRewards.set(id, false);
         }
     }
     
     public void claimFullReward() {
-        Collections.fill(reward, false);
+        Collections.fill(claimableRewards, false);
     }
     
     public void unlockRewardForAll() {
-        Collections.fill(reward, true);
+        Collections.fill(claimableRewards, true);
     }
     
     public void unlockRewardForRandom() {
-        int rewardId = (int) (Math.random() * reward.size());
-        reward.set(rewardId, true);
+        int rewardId = (int) (Math.random() * claimableRewards.size());
+        claimableRewards.set(rewardId, true);
     }
     
     private int getId(Player player) {
@@ -117,33 +117,33 @@ public class QuestData {
     }
     
     public void verifyTasksSize(Quest quest) {
-        while (tasks.size() < quest.getTasks().size()) {
-            tasks.add(quest.getTasks().get(tasks.size()).newQuestData());
+        while (taskData.size() < quest.getTasks().size()) {
+            taskData.add(quest.getTasks().get(taskData.size()).newQuestData());
         }
     }
     
     public <Data extends TaskData> Data getTaskData(Quest quest, int id, Class<Data> clazz, Supplier<Data> emptySupplier) {
         verifyTasksSize(quest);
         
-        TaskData data = tasks.get(id);
+        TaskData data = taskData.get(id);
         if (clazz.isInstance(data)) {
             return clazz.cast(data);
         } else {
             LOGGER.warn("Found task data of wrong type. Expected {}, was {}. Replacing with empty data of the correct type.", clazz, data == null ? null : data.getClass());
             Data newData = emptySupplier.get();
-            tasks.set(id, newData);
+            taskData.set(id, newData);
             return newData;
         }
     }
     
     public void clearTaskData(Quest quest) {
-        tasks.clear();
+        taskData.clear();
         verifyTasksSize(quest);
     }
     
     public void resetTaskData(int id, Supplier<? extends TaskData> emptySupplier) {
-        if (id < tasks.size()) {
-            tasks.set(id, emptySupplier.get());
+        if (id < taskData.size()) {
+            taskData.set(id, emptySupplier.get());
         }
     }
 }

--- a/common/src/main/java/hardcorequesting/common/quests/data/QuestData.java
+++ b/common/src/main/java/hardcorequesting/common/quests/data/QuestData.java
@@ -10,14 +10,14 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
 
 public class QuestData {
     private static final Logger LOGGER = LogManager.getLogger();
     
-    private boolean[] reward;
+    private final List<Boolean> reward = new ArrayList<>();
     public boolean completed;
     public boolean claimed;
     private final List<TaskData> tasks = new ArrayList<>();
@@ -30,70 +30,54 @@ public class QuestData {
     
     @Deprecated
     public int getPlayers() {
-        return reward.length;
+        return reward.size();
     }
     
     public void clearRewardClaims(int players) {
-        reward = new boolean[players];
+        reward.clear();
+        for (int i = 0; i < players; i++)
+            reward.add(false);
     }
     
     public boolean canClaimReward(int playerId) {
-        return reward[playerId];
+        return reward.get(playerId);
     }
     
     public void setCanClaimReward(int playerId, boolean canClaim) {
-        reward[playerId] = canClaim;
+        reward.set(playerId, canClaim);
     }
     
     public void removePlayer(int playerId) {
-        boolean[] old = reward;
-        reward = new boolean[old.length - 1];
-        for (int j = 0; j < reward.length; j++) {
-            if (j < playerId) {
-                reward[j] = old[j];
-            } else {
-                reward[j] = old[j + 1];
-            }
-        }
+        reward.remove(playerId);
     }
     
     public void insertPlayer(int playerId, boolean canClaim) {
-        boolean[] old = reward;
-        reward = new boolean[old.length + 1];
-        for (int j = 0; j < reward.length; j++) {
-            if (j == playerId) {
-                reward[j] = canClaim;
-            } else if (j < playerId) {
-                reward[j] = old[j];
-            } else {
-                reward[j] = old[j - 1];
-            }
-        }
+        reward.add(playerId, canClaim);
     }
     
     public boolean canClaimReward(Player player) {
         int id = getId(player);
-        return (id >= 0 && id < reward.length) && reward[id];
+        return (id >= 0 && id < reward.size()) && reward.get(id);
     }
     
     public void claimReward(Player player) {
         int id = getId(player);
-        if (id >= 0 && id < reward.length) {
-            reward[id] = false;
+        if (id >= 0 && id < reward.size()) {
+            reward.set(id, false);
         }
     }
     
     public void claimFullReward() {
-        Arrays.fill(reward, false);
+        Collections.fill(reward, false);
     }
     
     public void unlockRewardForAll() {
-        Arrays.fill(reward, true);
+        Collections.fill(reward, true);
     }
     
     public void unlockRewardForRandom() {
-        int rewardId = (int) (Math.random() * reward.length);
-        reward[rewardId] = true;
+        int rewardId = (int) (Math.random() * reward.size());
+        reward.set(rewardId, true);
     }
     
     private int getId(Player player) {

--- a/common/src/main/java/hardcorequesting/common/quests/data/QuestData.java
+++ b/common/src/main/java/hardcorequesting/common/quests/data/QuestData.java
@@ -24,13 +24,30 @@ public class QuestData {
     public boolean available = true;
     public long time;
     
+    // Create new data
     public QuestData(int players) {
         clearRewardClaims(players);
     }
     
-    @Deprecated
-    public int getPlayers() {
-        return reward.size();
+    // Initialize data from serialization
+    public QuestData() {}
+    
+    public void setRewardsFromSerialization(List<Boolean> claimableRewards) {
+        reward.clear();
+        reward.addAll(claimableRewards);
+    }
+    
+    public Iterable<Boolean> getRewardsForSerialization() {
+        return reward;
+    }
+    
+    public void setTaskDataFromSerialization(List<TaskData> taskData) {
+        tasks.clear();
+        tasks.addAll(taskData);
+    }
+    
+    public Iterable<TaskData> getTaskDataForSerialization() {
+        return tasks;
     }
     
     public void clearRewardClaims(int players) {
@@ -97,15 +114,6 @@ public class QuestData {
     
     public boolean canClaim() {
         return completed && !claimed;
-    }
-    
-    public void setTaskDataFromSerialization(List<TaskData> taskData) {
-        tasks.clear();
-        tasks.addAll(taskData);
-    }
-    
-    public Iterable<TaskData> getTaskDataForSerialization() {
-        return tasks;
     }
     
     public void verifyTasksSize(Quest quest) {

--- a/common/src/main/java/hardcorequesting/common/quests/data/QuestData.java
+++ b/common/src/main/java/hardcorequesting/common/quests/data/QuestData.java
@@ -112,7 +112,7 @@ public class QuestData {
         return -1;
     }
     
-    public boolean canClaim() {
+    public boolean canClaimTeamRewards() {
         return completed && !claimed;
     }
     

--- a/common/src/main/java/hardcorequesting/common/quests/data/QuestData.java
+++ b/common/src/main/java/hardcorequesting/common/quests/data/QuestData.java
@@ -9,7 +9,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Supplier;
 
 public class QuestData {
@@ -18,7 +19,7 @@ public class QuestData {
     public boolean[] reward;
     public boolean completed;
     public boolean claimed;
-    private TaskData[] tasks;
+    private final List<TaskData> tasks = new ArrayList<>();
     public boolean available = true;
     public long time;
     
@@ -60,49 +61,50 @@ public class QuestData {
     
     @Deprecated //Refer to Quest instead
     public int getTaskSize() {
-        return tasks.length;
+        return tasks.size();
     }
     
     @Nullable
     public TaskData getTaskData(int id) {
-        if (id >= tasks.length)
+        if (id >= tasks.size())
             return null;
-        else return tasks[id];
+        else return tasks.get(id);
     }
     
     public <Data extends TaskData> Data getTaskData(int id, Class<Data> clazz, Supplier<Data> emptySupplier) {
-        if (id >= tasks.length) {
-            tasks = Arrays.copyOf(tasks, id + 1);
+        if (id >= tasks.size()) {
+            while (id > tasks.size())
+                tasks.add(null);
             Data newData = emptySupplier.get();
-            tasks[id] = newData;
+            tasks.add(newData);
             return newData;
         }
     
-        TaskData data = tasks[id];
+        TaskData data = tasks.get(id);
         if (clazz.isInstance(data)) {
             return clazz.cast(data);
         } else {
             LOGGER.warn("Found task data of wrong type. Expected {}, was {}. Replacing with empty data of the correct type.", clazz, data == null ? null : data.getClass());
             Data newData = emptySupplier.get();
-            tasks[id] = newData;
+            tasks.set(id, newData);
             return newData;
         }
     }
     
-    public void clearTaskDataWithSize(int size) {
-        tasks = new TaskData[size];
+    public void clearTaskData() {
+        tasks.clear();
     }
     
     public void setTaskData(int id, TaskData data) {
-        if (id >= tasks.length) {
-            tasks = Arrays.copyOf(tasks, id + 1);
+        while (id >= tasks.size()) {
+            tasks.add(null);
         }
-        tasks[id] = data;
+        tasks.set(id, data);
     }
     
     public void resetTaskData(int id, Supplier<? extends TaskData> emptySupplier) {
-        if (id < tasks.length) {
-            tasks[id] = emptySupplier.get();
+        if (id < tasks.size()) {
+            tasks.set(id, emptySupplier.get());
         }
     }
 }

--- a/common/src/main/java/hardcorequesting/common/quests/data/QuestData.java
+++ b/common/src/main/java/hardcorequesting/common/quests/data/QuestData.java
@@ -20,7 +20,7 @@ public class QuestData {
     private final List<Boolean> claimableRewards = new ArrayList<>();
     private final List<TaskData> taskData = new ArrayList<>();
     public boolean completed;
-    public boolean claimed;
+    public boolean teamRewardClaimed;
     public boolean available = true;
     public long time;
     
@@ -56,7 +56,7 @@ public class QuestData {
             claimableRewards.add(false);
     }
     
-    public boolean canClaimReward(int playerId) {
+    public boolean canClaimPlayerReward(int playerId) {
         return claimableRewards.get(playerId);
     }
     
@@ -72,7 +72,7 @@ public class QuestData {
         claimableRewards.add(playerId, canClaim);
     }
     
-    public boolean canClaimReward(Player player) {
+    public boolean canClaimPlayerReward(Player player) {
         int id = getId(player);
         return (id >= 0 && id < claimableRewards.size()) && claimableRewards.get(id);
     }
@@ -113,7 +113,7 @@ public class QuestData {
     }
     
     public boolean canClaimTeamRewards() {
-        return completed && !claimed;
+        return completed && !teamRewardClaimed;
     }
     
     public void verifyTasksSize(Quest quest) {

--- a/common/src/main/java/hardcorequesting/common/quests/data/QuestData.java
+++ b/common/src/main/java/hardcorequesting/common/quests/data/QuestData.java
@@ -5,13 +5,20 @@ import hardcorequesting.common.quests.QuestingDataManager;
 import hardcorequesting.common.team.PlayerEntry;
 import hardcorequesting.common.team.Team;
 import net.minecraft.world.entity.player.Player;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+import java.util.function.Supplier;
 
 public class QuestData {
+    private static final Logger LOGGER = LogManager.getLogger();
     
     public boolean[] reward;
     public boolean completed;
     public boolean claimed;
-    public TaskData[] tasks;
+    private TaskData[] tasks;
     public boolean available = true;
     public long time;
     
@@ -49,5 +56,53 @@ public class QuestData {
     
     public boolean canClaim() {
         return completed && !claimed;
+    }
+    
+    @Deprecated //Refer to Quest instead
+    public int getTaskSize() {
+        return tasks.length;
+    }
+    
+    @Nullable
+    public TaskData getTaskData(int id) {
+        if (id >= tasks.length)
+            return null;
+        else return tasks[id];
+    }
+    
+    public <Data extends TaskData> Data getTaskData(int id, Class<Data> clazz, Supplier<Data> emptySupplier) {
+        if (id >= tasks.length) {
+            tasks = Arrays.copyOf(tasks, id + 1);
+            Data newData = emptySupplier.get();
+            tasks[id] = newData;
+            return newData;
+        }
+    
+        TaskData data = tasks[id];
+        if (clazz.isInstance(data)) {
+            return clazz.cast(data);
+        } else {
+            LOGGER.warn("Found task data of wrong type. Expected {}, was {}. Replacing with empty data of the correct type.", clazz, data == null ? null : data.getClass());
+            Data newData = emptySupplier.get();
+            tasks[id] = newData;
+            return newData;
+        }
+    }
+    
+    public void clearTaskDataWithSize(int size) {
+        tasks = new TaskData[size];
+    }
+    
+    public void setTaskData(int id, TaskData data) {
+        if (id >= tasks.length) {
+            tasks = Arrays.copyOf(tasks, id + 1);
+        }
+        tasks[id] = data;
+    }
+    
+    public void resetTaskData(int id, Supplier<? extends TaskData> emptySupplier) {
+        if (id < tasks.length) {
+            tasks[id] = emptySupplier.get();
+        }
     }
 }

--- a/common/src/main/java/hardcorequesting/common/quests/data/QuestData.java
+++ b/common/src/main/java/hardcorequesting/common/quests/data/QuestData.java
@@ -10,13 +10,14 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.Supplier;
 
 public class QuestData {
     private static final Logger LOGGER = LogManager.getLogger();
     
-    public boolean[] reward;
+    private boolean[] reward;
     public boolean completed;
     public boolean claimed;
     private final List<TaskData> tasks = new ArrayList<>();
@@ -24,10 +25,53 @@ public class QuestData {
     public long time;
     
     public QuestData(int players) {
+        clearRewardClaims(players);
+    }
+    
+    @Deprecated
+    public int getPlayers() {
+        return reward.length;
+    }
+    
+    public void clearRewardClaims(int players) {
         reward = new boolean[players];
     }
     
-    public boolean getReward(Player player) {
+    public boolean canClaimReward(int playerId) {
+        return reward[playerId];
+    }
+    
+    public void setCanClaimReward(int playerId, boolean canClaim) {
+        reward[playerId] = canClaim;
+    }
+    
+    public void removePlayer(int playerId) {
+        boolean[] old = reward;
+        reward = new boolean[old.length - 1];
+        for (int j = 0; j < reward.length; j++) {
+            if (j < playerId) {
+                reward[j] = old[j];
+            } else {
+                reward[j] = old[j + 1];
+            }
+        }
+    }
+    
+    public void insertPlayer(int playerId, boolean canClaim) {
+        boolean[] old = reward;
+        reward = new boolean[old.length + 1];
+        for (int j = 0; j < reward.length; j++) {
+            if (j == playerId) {
+                reward[j] = canClaim;
+            } else if (j < playerId) {
+                reward[j] = old[j];
+            } else {
+                reward[j] = old[j - 1];
+            }
+        }
+    }
+    
+    public boolean canClaimReward(Player player) {
         int id = getId(player);
         return (id >= 0 && id < reward.length) && reward[id];
     }
@@ -37,6 +81,19 @@ public class QuestData {
         if (id >= 0 && id < reward.length) {
             reward[id] = false;
         }
+    }
+    
+    public void claimFullReward() {
+        Arrays.fill(reward, false);
+    }
+    
+    public void unlockRewardForAll() {
+        Arrays.fill(reward, true);
+    }
+    
+    public void unlockRewardForRandom() {
+        int rewardId = (int) (Math.random() * reward.length);
+        reward[rewardId] = true;
     }
     
     private int getId(Player player) {

--- a/common/src/main/java/hardcorequesting/common/quests/reward/QuestRewards.java
+++ b/common/src/main/java/hardcorequesting/common/quests/reward/QuestRewards.java
@@ -15,8 +15,6 @@ import hardcorequesting.common.network.NetworkManager;
 import hardcorequesting.common.quests.Quest;
 import hardcorequesting.common.quests.QuestingDataManager;
 import hardcorequesting.common.quests.data.QuestData;
-import hardcorequesting.common.team.RewardSetting;
-import hardcorequesting.common.team.Team;
 import hardcorequesting.common.util.EditType;
 import hardcorequesting.common.util.SaveHelper;
 import hardcorequesting.common.util.Translator;
@@ -26,7 +24,6 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.core.NonNullList;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.FormattedText;
-import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.Tuple;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
@@ -144,16 +141,7 @@ public class QuestRewards {
         claimedAny |= tryClaimCommandReward(player, data);
     
         if (claimedAny) {
-            data.teamRewardClaimed = true;
-            Team team = QuestingDataManager.getInstance().getQuestingData(player).getTeam();
-            if (!team.isSingle() && team.getRewardSetting() == RewardSetting.ANY) {
-                data.claimFullReward();
-                quest.sendUpdatedDataToTeam(player);
-            } else {
-                data.claimReward(player);
-                if (player instanceof ServerPlayer)
-                    quest.sendUpdatedData((ServerPlayer) player);
-            }
+            data.claimReward(quest, player);
             SoundHandler.play(Sounds.COMPLETE, player);
         }
     }

--- a/common/src/main/java/hardcorequesting/common/quests/reward/QuestRewards.java
+++ b/common/src/main/java/hardcorequesting/common/quests/reward/QuestRewards.java
@@ -1,0 +1,497 @@
+package hardcorequesting.common.quests.reward;
+
+import com.google.common.collect.Lists;
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vertex.PoseStack;
+import hardcorequesting.common.client.ClientChange;
+import hardcorequesting.common.client.EditMode;
+import hardcorequesting.common.client.interfaces.*;
+import hardcorequesting.common.client.interfaces.edit.GuiEditMenuReputationReward;
+import hardcorequesting.common.client.interfaces.edit.PickItemMenu;
+import hardcorequesting.common.client.sounds.SoundHandler;
+import hardcorequesting.common.client.sounds.Sounds;
+import hardcorequesting.common.event.EventTrigger;
+import hardcorequesting.common.network.NetworkManager;
+import hardcorequesting.common.quests.Quest;
+import hardcorequesting.common.quests.QuestingDataManager;
+import hardcorequesting.common.quests.data.QuestData;
+import hardcorequesting.common.team.RewardSetting;
+import hardcorequesting.common.team.Team;
+import hardcorequesting.common.util.EditType;
+import hardcorequesting.common.util.SaveHelper;
+import hardcorequesting.common.util.Translator;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.client.Minecraft;
+import net.minecraft.core.NonNullList;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.FormattedText;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.util.Tuple;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TooltipFlag;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+public class QuestRewards {
+    public static final int START_X = Quest.START_X;
+    private static final int REWARD_STR_Y = 140;
+    private static final int REWARD_Y = 150;
+    private static final int REWARD_Y_OFFSET = 40;
+    private static final int REWARD_OFFSET = 20;
+    private static final int ITEM_SIZE = 18;
+    private static final int MAX_REWARD_SLOTS = 7;
+    private static final int MAX_SELECT_REWARD_SLOTS = 4;
+    private static final int REPUTATION_X = 142;
+    private static final int REPUTATION_Y = 133;
+    private static final int REPUTATION_Y_LOWER = 150;
+    private static final int REPUTATION_SIZE = 16;
+    private static final int REPUTATION_SRC_X = 30;
+    private static final int REPUTATION_SRC_Y = 82;
+    
+    private int selectedReward = -1;
+    private int lastClicked;
+    private final LargeButton claimButton = new LargeButton("hqm.quest.claim", 100, 190) {
+        @Override
+        public boolean isEnabled(GuiBase gui, Player player) {
+            return hasReward(quest.getQuestData(player), player) && (rewardChoices.isEmpty() || selectedReward != -1) && quest.isEnabled(player);
+        }
+    
+        @Override
+        public boolean isVisible(GuiBase gui, Player player) {
+            return hasReward(quest.getQuestData(player), player);
+        }
+    
+        @Override
+        public void onClick(GuiBase gui, Player player) {
+            NetworkManager.sendToServer(ClientChange.CLAIM_QUEST.build(new Tuple<>(quest.getQuestId(), rewardChoices.isEmpty() ? -1 : selectedReward)));
+        }
+    };
+    
+    private final Quest quest;
+    private final ItemStackRewardList rewards = new ItemStackRewardList();
+    private final ItemStackRewardList rewardChoices = new ItemStackRewardList();
+    private final CommandRewardList commandRewardList = new CommandRewardList();
+    private List<ReputationReward> reputationRewards;
+    
+    
+    public QuestRewards(Quest quest) {
+        this.quest = quest;
+    }
+    
+    public NonNullList<ItemStack> getReward() {
+        return rewards.toList();
+    }
+    
+    public void setReward(NonNullList<ItemStack> reward) {
+        this.rewards.set(reward);
+    }
+    
+    public NonNullList<ItemStack> getRewardChoice() {
+        return rewardChoices.toList();
+    }
+    
+    public void setRewardChoice(NonNullList<ItemStack> rewardChoice) {
+        this.rewardChoices.set(rewardChoice);
+    }
+    
+    public String[] getCommandRewardsAsStrings() {
+        return this.commandRewardList.asStrings();
+    }
+    
+    public void setCommandRewards(String[] commands) {
+        this.commandRewardList.set(commands);
+    }
+    
+    public void addCommand(String command) {
+        this.commandRewardList.add(command);
+    }
+    
+    public void editCommand(int id, String command) {
+        this.commandRewardList.set(id, command);
+    }
+    
+    public void removeCommand(int id) {
+        this.commandRewardList.remove(id);
+    }
+    
+    public List<ReputationReward> getReputationRewards() {
+        return reputationRewards;
+    }
+    
+    public void setReputationRewards(List<ReputationReward> reputationRewards) {
+        this.reputationRewards = reputationRewards;
+    }
+    
+    public boolean hasReward(QuestData data, Player player) {
+        return (data.canClaimReward(player) && (!rewards.isEmpty() || !rewardChoices.isEmpty())) || (data.canClaim() && (reputationRewards != null || !commandRewardList.isEmpty()));
+    }
+    
+    public void claimReward(Player player, int selectedReward) {
+        QuestData data = quest.getQuestData(player);
+        if (hasReward(data, player)) {
+            boolean sentInfo = false;
+            if (data.canClaimReward(player) && (!rewards.isEmpty() || !rewardChoices.isEmpty())) {
+                List<ItemStack> items = new ArrayList<>();
+                if (!rewards.isEmpty()) {
+                    for (ItemStack stack : rewards.toList()) {
+                        items.add(stack.copy());
+                    }
+                }
+                if (!rewardChoices.isEmpty()) {
+                    if (selectedReward >= 0 && selectedReward < rewardChoices.size()) {
+                        items.add(rewardChoices.getReward(selectedReward).copy());
+                    } else {
+                        return;
+                    }
+                }
+                
+                List<ItemStack> itemsToAdd = new ArrayList<>();
+                for (ItemStack stack : items) {
+                    boolean added = false;
+                    for (ItemStack stack1 : itemsToAdd) {
+                        if (stack.sameItemStackIgnoreDurability(stack1) && ItemStack.tagMatches(stack, stack1)) {
+                            stack1.grow(stack.getCount());
+                            added = true;
+                            break;
+                        }
+                    }
+                    
+                    if (!added) {
+                        itemsToAdd.add(stack.copy());
+                    }
+                }
+                
+                List<ItemStack> itemsToCheck = new ArrayList<>();
+                for (ItemStack stack : itemsToAdd) {
+                    itemsToCheck.add(stack.copy());
+                }
+                for (int i = 0; i < player.getInventory().items.size(); i++) {
+                    for (ItemStack stack1 : itemsToCheck) {
+                        if (stack1.getCount() > 0) {
+                            ItemStack stack = player.getInventory().items.get(i);
+                            if (stack == ItemStack.EMPTY) {
+                                stack1.shrink(stack1.getMaxStackSize());
+                                break;
+                            } else if (stack.sameItemStackIgnoreDurability(stack1) && ItemStack.tagMatches(stack1, stack)) {
+                                stack1.shrink(stack1.getMaxStackSize() - stack.getCount());
+                                break;
+                            }
+                        }
+                    }
+                    
+                }
+                
+                
+                boolean valid = true;
+                for (ItemStack stack : itemsToCheck) {
+                    if (stack.getCount() > 0) {
+                        valid = false;
+                        break;
+                    }
+                }
+                
+                if (valid) {
+                    addItems(player, itemsToAdd);
+                    player.getInventory().setChanged();
+                    Team team = QuestingDataManager.getInstance().getQuestingData(player).getTeam();
+                    if (!team.isSingle() && team.getRewardSetting() == RewardSetting.ANY) {
+                        data.claimFullReward();
+                        quest.sendUpdatedDataToTeam(player);
+                    } else {
+                        data.claimReward(player);
+                        if (player instanceof ServerPlayer)
+                            quest.sendUpdatedData((ServerPlayer) player);
+                    }
+                    sentInfo = true;
+                } else {
+                    return;
+                }
+            }
+            
+            
+            if (reputationRewards != null && data.canClaim()) {
+                data.claimed = true;
+                QuestingDataManager.getInstance().getQuestingData(player).getTeam().receiveAndSyncReputation(quest, reputationRewards);
+                EventTrigger.instance().onReputationChange(new EventTrigger.ReputationEvent(player));
+                sentInfo = true;
+            }
+            
+            if (data.canClaim()) {
+                data.claimed = true;
+                commandRewardList.executeAll(player);
+                sentInfo = true;
+            }
+            
+            if (sentInfo) {
+                SoundHandler.play(Sounds.COMPLETE, player);
+            }
+            
+        }
+    }
+    
+    private void setReward(ItemStack stack, int id, boolean isStandardReward) {
+        ItemStackRewardList rewardList = isStandardReward ? this.rewards : this.rewardChoices;
+        
+        if (id < rewardList.size()) {
+            rewardList.set(id, stack);
+            SaveHelper.add(EditType.REWARD_CHANGE);
+        } else {
+            SaveHelper.add(EditType.REWARD_CREATE);
+            rewardList.add(stack);
+        }
+    }
+    
+    @Environment(EnvType.CLIENT)
+    public void draw(PoseStack matrices, GuiQuestBook gui, Player player, int mX, int mY, QuestData data) {
+        if (selectedReward != -1 && !hasReward(data, player)) {
+            selectedReward = -1;
+        }
+        if (!rewards.isEmpty() || Quest.canQuestsBeEdited()) {
+            gui.drawString(matrices, Translator.translatable("hqm.quest.rewards"), START_X, REWARD_STR_Y, 0x404040);
+            drawRewards(gui, rewards.toList(), REWARD_Y, -1, mX, mY, MAX_SELECT_REWARD_SLOTS);
+            if (!rewardChoices.isEmpty() || Quest.canQuestsBeEdited()) {
+                gui.drawString(matrices, Translator.translatable("hqm.quest.pickOne"), START_X, REWARD_STR_Y + REWARD_Y_OFFSET, 0x404040);
+                drawRewards(gui, rewardChoices.toList(), REWARD_Y + REWARD_Y_OFFSET, selectedReward, mX, mY, MAX_REWARD_SLOTS);
+            }
+        } else if (!rewardChoices.isEmpty()) {
+            gui.drawString(matrices, Translator.translatable("hqm.quest.pickOneReward"), START_X, REWARD_STR_Y, 0x404040);
+            drawRewards(gui, rewardChoices.toList(), REWARD_Y, selectedReward, mX, mY, MAX_REWARD_SLOTS);
+        }
+        
+        claimButton.draw(matrices, gui, player, mX, mY);
+        
+        RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
+        ResourceHelper.bindResource(GuiQuestBook.MAP_TEXTURE);
+        
+    
+        if (reputationRewards != null || Quest.canQuestsBeEdited()) {
+            boolean claimed = data.claimed || reputationRewards == null;
+        
+            int backgroundIndex = claimed ? 2 : isOnReputationIcon(gui, mX, mY) ? 1 : 0;
+            int foregroundIndex;
+            if (claimed) {
+                foregroundIndex = 3;
+            } else {
+                boolean positive = false;
+                boolean negative = false;
+                for (ReputationReward reputationReward : reputationRewards) {
+                    if (reputationReward.getValue() < 0) {
+                        negative = true;
+                    } else if (reputationReward.getValue() > 0) {
+                        positive = true;
+                    }
+                }
+            
+                if (negative == positive) {
+                    foregroundIndex = 2;
+                } else {
+                    foregroundIndex = positive ? 0 : 1;
+                }
+            }
+            
+            int y = getRepIconY();
+            foregroundIndex += 3;
+            gui.drawRect(REPUTATION_X, y, REPUTATION_SRC_X + backgroundIndex * REPUTATION_SIZE, REPUTATION_SRC_Y, REPUTATION_SIZE, REPUTATION_SIZE);
+            gui.drawRect(REPUTATION_X, y, REPUTATION_SRC_X + foregroundIndex * REPUTATION_SIZE, REPUTATION_SRC_Y, REPUTATION_SIZE, REPUTATION_SIZE);
+        }
+    }
+    
+    @Environment(EnvType.CLIENT)
+    public void drawTooltips(PoseStack matrices, GuiQuestBook gui, Player player, int mX, int mY, QuestData data) {
+        if (!rewards.isEmpty() || Quest.canQuestsBeEdited()) {
+            drawRewardMouseOver(matrices, gui, rewards.toList(), REWARD_Y, -1, mX, mY);
+            if (!rewardChoices.isEmpty() || Quest.canQuestsBeEdited()) {
+                drawRewardMouseOver(matrices, gui, rewardChoices.toList(), REWARD_Y + REWARD_Y_OFFSET, selectedReward, mX, mY);
+            }
+        } else if (!rewardChoices.isEmpty()) {
+            drawRewardMouseOver(matrices, gui, rewardChoices.toList(), REWARD_Y, selectedReward, mX, mY);
+        }
+    
+        claimButton.renderTooltip(matrices, gui, player, mX, mY);
+        
+        if (reputationRewards != null && isOnReputationIcon(gui, mX, mY)) {
+            List<FormattedText> str = new ArrayList<>();
+            for (ReputationReward reputationReward : reputationRewards) {
+                if (reputationReward.getValue() != 0 && reputationReward.getReward() != null && reputationReward.getReward().isValid()) {
+                    str.add(Translator.plain(reputationReward.getLabel()));
+                }
+                
+            }
+            
+            List<FormattedText> commentLines = gui.getLinesFromText(Translator.translatable("hqm.quest.partyRepReward" + (data.claimed ? "Claimed" : "")), 1, 200);
+            if (commentLines != null) {
+                str.add(FormattedText.EMPTY);
+                for (FormattedText commentLine : commentLines) {
+                    str.add(Translator.text(Translator.rawString(commentLine), GuiColor.GRAY));
+                }
+            }
+            gui.renderTooltipL(matrices, str, mX + gui.getLeft(), mY + gui.getTop());
+        }
+    }
+    
+    @Environment(EnvType.CLIENT)
+    public void onClick(GuiQuestBook gui, Player player, int mX, int mY) {
+        if (!rewards.isEmpty() || Quest.canQuestsBeEdited()) {
+            handleRewardClick(gui, player, rewards.toList(), REWARD_Y, false, mX, mY);
+            if (!rewardChoices.isEmpty() || Quest.canQuestsBeEdited()) {
+                handleRewardClick(gui, player, rewardChoices.toList(), REWARD_Y + REWARD_Y_OFFSET, true, mX, mY);
+            }
+        } else if (!rewardChoices.isEmpty()) {
+            handleRewardClick(gui, player, rewardChoices.toList(), REWARD_Y, true, mX, mY);
+        }
+        
+        if (Quest.canQuestsBeEdited() && gui.getCurrentMode() == EditMode.REPUTATION_REWARD) {
+            if (isOnReputationIcon(gui, mX, mY)) {
+                gui.setEditMenu(new GuiEditMenuReputationReward(gui, player, reputationRewards));
+            }
+        }
+    
+        if (claimButton.inButtonBounds(gui, mX, mY) && claimButton.isVisible(gui, player) && claimButton.isEnabled(gui, player)) {
+            claimButton.onClick(gui, player);
+        }
+    }
+    
+    @Environment(EnvType.CLIENT)
+    private NonNullList<ItemStack> getEditFriendlyRewards(NonNullList<ItemStack> rewards, int max) {
+        if (rewards.isEmpty()) {
+            return NonNullList.withSize(1, ItemStack.EMPTY);
+        } else if (Quest.canQuestsBeEdited() && rewards.size() < max) {
+            NonNullList<ItemStack> rewardsWithEmpty = NonNullList.create();
+            rewardsWithEmpty.addAll(rewards);
+            rewardsWithEmpty.add(ItemStack.EMPTY);
+            return rewardsWithEmpty;
+        } else {
+            return rewards;
+        }
+    }
+    
+    @Environment(EnvType.CLIENT)
+    private void drawRewards(GuiQuestBook gui, NonNullList<ItemStack> rewards, int y, int selected, int mX, int mY, int max) {
+        rewards = getEditFriendlyRewards(rewards, max);
+        
+        
+        for (int i = 0; i < rewards.size(); i++) {
+            gui.drawItemStack(rewards.get(i), START_X + i * REWARD_OFFSET, y, mX, mY, selected == i);
+        }
+    }
+    
+    @Environment(EnvType.CLIENT)
+    private void drawRewardMouseOver(PoseStack matrices, GuiQuestBook gui, NonNullList<ItemStack> rewards, int y, int selected, int mX, int mY) {
+        if (rewards != null) {
+            for (int i = 0; i < rewards.size(); i++) {
+                if (gui.inBounds(START_X + i * REWARD_OFFSET, y, ITEM_SIZE, ITEM_SIZE, mX, mY)) {
+                    if (!rewards.get(i).isEmpty()) {
+                        GuiQuestBook.setSelectedStack(rewards.get(i));
+                        List<Component> str = rewards.get(i).getTooltipLines(Minecraft.getInstance().player, Minecraft.getInstance().options.advancedItemTooltips ? TooltipFlag.Default.ADVANCED : TooltipFlag.Default.NORMAL);
+                        List<FormattedText> list2 = Lists.newArrayList(str);
+                        if (selected == i) {
+                            list2.add(FormattedText.EMPTY);
+                            list2.add(Translator.translatable("hqm.quest.selected", GuiColor.GREEN));
+                        }
+                        gui.renderTooltipL(matrices, list2, gui.getLeft() + mX, gui.getTop() + mY);
+                    }
+                    break;
+                }
+            }
+        }
+    }
+    
+    @Environment(EnvType.CLIENT)
+    private void handleRewardClick(GuiQuestBook gui, Player player, NonNullList<ItemStack> rawRewards, int y, boolean canSelect, int mX, int mY) {
+        NonNullList<ItemStack> rewards = getEditFriendlyRewards(rawRewards, canSelect ? MAX_SELECT_REWARD_SLOTS : MAX_REWARD_SLOTS);
+        
+        boolean doubleClick = false;
+        
+        for (int i = 0; i < rewards.size(); i++) {
+            if (gui.inBounds(START_X + i * REWARD_OFFSET, y, ITEM_SIZE, ITEM_SIZE, mX, mY)) {
+                if (gui.getCurrentMode() == EditMode.NORMAL) {
+                    int lastDiff = player.tickCount - lastClicked;
+                    if (lastDiff < 0) {
+                        lastClicked = player.tickCount;
+                    } else if (lastDiff < 6) {
+                        doubleClick = true;
+                    } else {
+                        lastClicked = player.tickCount;
+                    }
+                }
+                if (canSelect && (!Quest.canQuestsBeEdited() || (gui.getCurrentMode() == EditMode.NORMAL && !doubleClick))) {
+                    if (selectedReward == i) {
+                        selectedReward = -1;
+                    } else if (!rewards.get(i).isEmpty()) {
+                        selectedReward = i;
+                    }
+                } else if (Quest.canQuestsBeEdited()) {
+                    if (gui.getCurrentMode() == EditMode.DELETE) {
+                        if (i < rawRewards.size()) {
+                            rawRewards.remove(i);
+                            if (canSelect && selectedReward != -1) {
+                                if (selectedReward == i) {
+                                    selectedReward = -1;
+                                } else if (selectedReward > i) {
+                                    selectedReward--;
+                                }
+                            }
+                            
+                            if (canSelect) {
+                                this.rewardChoices.set(rawRewards);
+                            } else {
+                                this.rewards.set(rawRewards);
+                            }
+                            SaveHelper.add(EditType.REWARD_REMOVE);
+                        }
+                    } else if (gui.getCurrentMode() == EditMode.ITEM || doubleClick) {
+                        final int id = i;
+                        PickItemMenu.display(gui, player, rewards.get(i), PickItemMenu.Type.ITEM, rewards.get(i).isEmpty() ? 1 : rewards.get(i).getCount(),
+                                result -> this.setReward(result.getWithAmount(), id, !canSelect));
+                    }
+                }
+                
+                break;
+            }
+        }
+    }
+    
+    @Environment(EnvType.CLIENT)
+    private int getRepIconY() {
+        return rewards.size() <= MAX_REWARD_SLOTS - (Quest.canQuestsBeEdited() ? 2 : 1) ? REPUTATION_Y_LOWER : REPUTATION_Y;
+    }
+    
+    @Environment(EnvType.CLIENT)
+    private boolean isOnReputationIcon(GuiQuestBook gui, int mX, int mY) {
+        return gui.inBounds(REPUTATION_X, getRepIconY(), REPUTATION_SIZE, REPUTATION_SIZE, mX, mY);
+    }
+    
+    public static void addItems(Player player, List<ItemStack> itemsToAdd) {
+        for (int i = 0; i < player.getInventory().items.size(); i++) {
+            Iterator<ItemStack> iterator = itemsToAdd.iterator();
+            while (iterator.hasNext()) {
+                ItemStack nextStack = iterator.next();
+                ItemStack stack = player.getInventory().items.get(i);
+                
+                if (stack.isEmpty()) {
+                    int amount = Math.min(nextStack.getMaxStackSize(), nextStack.getCount());
+                    ItemStack copyStack = nextStack.copy();
+                    copyStack.setCount(amount);
+                    player.getInventory().items.set(i, copyStack);
+                    nextStack.shrink(amount);
+                    if (nextStack.getCount() <= 0) {
+                        iterator.remove();
+                    }
+                    break;
+                } else if (stack.sameItemStackIgnoreDurability(nextStack) && ItemStack.tagMatches(nextStack, stack)) {
+                    int amount = Math.min(nextStack.getMaxStackSize() - stack.getCount(), nextStack.getCount());
+                    stack.grow(amount);
+                    nextStack.shrink(amount);
+                    if (nextStack.getCount() <= 0) {
+                        iterator.remove();
+                    }
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/common/src/main/java/hardcorequesting/common/quests/reward/QuestRewards.java
+++ b/common/src/main/java/hardcorequesting/common/quests/reward/QuestRewards.java
@@ -250,6 +250,25 @@ public class QuestRewards {
         if (selectedReward != -1 && !hasReward(data, player)) {
             selectedReward = -1;
         }
+        
+        drawItemRewards(matrices, gui, mX, mY);
+    
+        claimButton.draw(matrices, gui, player, mX, mY);
+        
+        drawReputationIcon(gui, mX, mY, data);
+    }
+    
+    @Environment(EnvType.CLIENT)
+    public void drawTooltips(PoseStack matrices, GuiQuestBook gui, Player player, int mX, int mY, QuestData data) {
+        drawItemRewardTooltips(matrices, gui, mX, mY);
+    
+        claimButton.renderTooltip(matrices, gui, player, mX, mY);
+    
+        drawRepIconTooltip(matrices, gui, mX, mY, data);
+    }
+    
+    @Environment(EnvType.CLIENT)
+    private void drawItemRewards(PoseStack matrices, GuiQuestBook gui, int mX, int mY) {
         if (!rewards.isEmpty() || Quest.canQuestsBeEdited()) {
             gui.drawString(matrices, Translator.translatable("hqm.quest.rewards"), START_X, REWARD_STR_Y, 0x404040);
             drawRewards(gui, rewards.toList(), REWARD_Y, -1, mX, mY, MAX_SELECT_REWARD_SLOTS);
@@ -261,16 +280,28 @@ public class QuestRewards {
             gui.drawString(matrices, Translator.translatable("hqm.quest.pickOneReward"), START_X, REWARD_STR_Y, 0x404040);
             drawRewards(gui, rewardChoices.toList(), REWARD_Y, selectedReward, mX, mY, MAX_REWARD_SLOTS);
         }
-        
-        claimButton.draw(matrices, gui, player, mX, mY);
-        
+    }
+    
+    @Environment(EnvType.CLIENT)
+    private void drawItemRewardTooltips(PoseStack matrices, GuiQuestBook gui, int mX, int mY) {
+        if (!rewards.isEmpty() || Quest.canQuestsBeEdited()) {
+            drawRewardMouseOver(matrices, gui, rewards.toList(), REWARD_Y, -1, mX, mY);
+            if (!rewardChoices.isEmpty() || Quest.canQuestsBeEdited()) {
+                drawRewardMouseOver(matrices, gui, rewardChoices.toList(), REWARD_Y + REWARD_Y_OFFSET, selectedReward, mX, mY);
+            }
+        } else if (!rewardChoices.isEmpty()) {
+            drawRewardMouseOver(matrices, gui, rewardChoices.toList(), REWARD_Y, selectedReward, mX, mY);
+        }
+    }
+    
+    @Environment(EnvType.CLIENT)
+    private void drawReputationIcon(GuiQuestBook gui, int mX, int mY, QuestData data) {
         RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
         ResourceHelper.bindResource(GuiQuestBook.MAP_TEXTURE);
         
-    
         if (reputationRewards != null || Quest.canQuestsBeEdited()) {
             boolean claimed = data.claimed || reputationRewards == null;
-        
+            
             int backgroundIndex = claimed ? 2 : isOnReputationIcon(gui, mX, mY) ? 1 : 0;
             int foregroundIndex;
             if (claimed) {
@@ -285,7 +316,7 @@ public class QuestRewards {
                         positive = true;
                     }
                 }
-            
+                
                 if (negative == positive) {
                     foregroundIndex = 2;
                 } else {
@@ -301,18 +332,7 @@ public class QuestRewards {
     }
     
     @Environment(EnvType.CLIENT)
-    public void drawTooltips(PoseStack matrices, GuiQuestBook gui, Player player, int mX, int mY, QuestData data) {
-        if (!rewards.isEmpty() || Quest.canQuestsBeEdited()) {
-            drawRewardMouseOver(matrices, gui, rewards.toList(), REWARD_Y, -1, mX, mY);
-            if (!rewardChoices.isEmpty() || Quest.canQuestsBeEdited()) {
-                drawRewardMouseOver(matrices, gui, rewardChoices.toList(), REWARD_Y + REWARD_Y_OFFSET, selectedReward, mX, mY);
-            }
-        } else if (!rewardChoices.isEmpty()) {
-            drawRewardMouseOver(matrices, gui, rewardChoices.toList(), REWARD_Y, selectedReward, mX, mY);
-        }
-    
-        claimButton.renderTooltip(matrices, gui, player, mX, mY);
-        
+    private void drawRepIconTooltip(PoseStack matrices, GuiQuestBook gui, int mX, int mY, QuestData data) {
         if (reputationRewards != null && isOnReputationIcon(gui, mX, mY)) {
             List<FormattedText> str = new ArrayList<>();
             for (ReputationReward reputationReward : reputationRewards) {

--- a/common/src/main/java/hardcorequesting/common/quests/reward/QuestRewards.java
+++ b/common/src/main/java/hardcorequesting/common/quests/reward/QuestRewards.java
@@ -214,17 +214,16 @@ public class QuestRewards {
             
             
             if (reputationRewards != null && data.canClaim()) {
-                data.claimed = true;
                 QuestingDataManager.getInstance().getQuestingData(player).getTeam().receiveAndSyncReputation(quest, reputationRewards);
                 EventTrigger.instance().onReputationChange(new EventTrigger.ReputationEvent(player));
                 sentInfo = true;
             }
             
             if (data.canClaim()) {
-                data.claimed = true;
                 commandRewardList.executeAll(player);
                 sentInfo = true;
             }
+            data.claimed = true;
             
             if (sentInfo) {
                 SoundHandler.play(Sounds.COMPLETE, player);

--- a/common/src/main/java/hardcorequesting/common/quests/task/QuestTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/QuestTask.java
@@ -160,7 +160,7 @@ public abstract class QuestTask<Data extends TaskData> {
             return newQuestData(); // possible fix for #247
         }
         
-        return questData.getTaskData(id, dataType, this::newQuestData);
+        return questData.getTaskData(parent, id, dataType, this::newQuestData);
     }
     
     public abstract Data newQuestData();

--- a/common/src/main/java/hardcorequesting/common/quests/task/QuestTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/QuestTask.java
@@ -34,14 +34,11 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.util.*;
 
 public abstract class QuestTask<Data extends TaskData> {
-    private static final Logger LOGGER = LogManager.getLogger();
     
     private final Class<Data> dataType;
     public String description;
@@ -163,20 +160,7 @@ public abstract class QuestTask<Data extends TaskData> {
             return newQuestData(); // possible fix for #247
         }
         
-        if (id >= questData.tasks.length) {
-            questData.tasks = Arrays.copyOf(questData.tasks, id + 1);
-            questData.tasks[id] = newQuestData();
-        }
-        
-        TaskData data = questData.tasks[id];
-        if (dataType.isInstance(data)) {
-            return dataType.cast(data);
-        } else {
-            LOGGER.warn("Found task data of wrong type. Expected {}, was {}. Replacing with empty data of the correct type.", dataType, data == null ? null : data.getClass());
-            Data newData = newQuestData();
-            questData.tasks[id] = newData;
-            return newData;
-        }
+        return questData.getTaskData(id, dataType, this::newQuestData);
     }
     
     public abstract Data newQuestData();
@@ -268,10 +252,7 @@ public abstract class QuestTask<Data extends TaskData> {
     public abstract void mergeProgress(UUID playerId, Data own, Data other);
     
     public void resetData(UUID playerId) {
-        QuestData questData = parent.getQuestData(playerId);
-        if (id < questData.tasks.length) {
-            questData.tasks[id] = newQuestData();
-        }
+        parent.getQuestData(playerId).resetTaskData(id, this::newQuestData);
     }
     
     protected abstract void setComplete(Data data);

--- a/common/src/main/java/hardcorequesting/common/quests/task/QuestTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/QuestTask.java
@@ -67,7 +67,7 @@ public abstract class QuestTask<Data extends TaskData> {
         QuestData data = quest.getQuestData(uuid);
         
         data.completed = true;
-        data.claimed = false;
+        data.teamRewardClaimed = false;
         data.available = false;
         data.time = Quest.serverTicker.getHours();
         

--- a/common/src/main/java/hardcorequesting/common/quests/task/QuestTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/QuestTask.java
@@ -73,10 +73,9 @@ public abstract class QuestTask<Data extends TaskData> {
         
         
         if (QuestingDataManager.getInstance().getQuestingData(uuid).getTeam().getRewardSetting() == RewardSetting.RANDOM) {
-            int rewardId = (int) (Math.random() * data.reward.length);
-            data.reward[rewardId] = true;
+            data.unlockRewardForRandom();
         } else {
-            Arrays.fill(data.reward, true);
+           data.unlockRewardForAll();
         }
         quest.sendUpdatedDataToTeam(uuid);
         TeamLiteStat.refreshTeam(QuestingDataManager.getInstance().getQuestingData(uuid).getTeam());

--- a/common/src/main/java/hardcorequesting/common/reputation/Reputation.java
+++ b/common/src/main/java/hardcorequesting/common/reputation/Reputation.java
@@ -172,7 +172,7 @@ public class Reputation {
                                 }
                             }
                             
-                            List<ReputationReward> rewards = quest.getReputationRewards();
+                            List<ReputationReward> rewards = quest.getRewards().getReputationRewards();
                             if (rewards != null) {
                                 rewards.removeIf(reward -> reputation.equals(reward.getReward()));
                             }

--- a/common/src/main/java/hardcorequesting/common/team/Team.java
+++ b/common/src/main/java/hardcorequesting/common/team/Team.java
@@ -80,7 +80,7 @@ public class Team {
     public void resetCompletion(Quest quest) {
         QuestData data = getQuestData(quest.getQuestId());
         data.completed = false;
-        data.claimed = false;
+        data.teamRewardClaimed = false;
         data.available = true;
         refreshData();
     }
@@ -176,7 +176,7 @@ public class Team {
                     QuestData leaveData = newSingleTeam.questData.get(i);
                     QuestData data = questData.get(i);
                     if (data != null) {
-                        leaveData.setCanClaimReward(0, data.canClaimReward(id));
+                        leaveData.setCanClaimReward(0, data.canClaimPlayerReward(id));
                         
                         data.removePlayer(id);
                     }

--- a/common/src/main/java/hardcorequesting/common/team/Team.java
+++ b/common/src/main/java/hardcorequesting/common/team/Team.java
@@ -176,17 +176,9 @@ public class Team {
                     QuestData leaveData = newSingleTeam.questData.get(i);
                     QuestData data = questData.get(i);
                     if (data != null) {
-                        boolean[] old = data.reward;
-                        data.reward = new boolean[old.length - 1];
-                        for (int j = 0; j < data.reward.length; j++) {
-                            if (j < id) {
-                                data.reward[j] = old[j];
-                            } else {
-                                data.reward[j] = old[j + 1];
-                            }
-                        }
+                        leaveData.setCanClaimReward(0, data.canClaimReward(id));
                         
-                        leaveData.reward[0] = old[id];
+                        data.removePlayer(id);
                     }
                 }
                 
@@ -261,7 +253,7 @@ public class Team {
         int playerCount = getPlayerCount();
         for (Quest quest : Quest.getQuests().values()) {
             if (quest != null && questData.get(quest.getQuestId()) != null) {
-                quest.initRewards(playerCount, questData.get(quest.getQuestId()));
+                questData.get(quest.getQuestId()).clearRewardClaims(playerCount);
             }
         }
         refreshData();

--- a/common/src/main/java/hardcorequesting/common/team/TeamAction.java
+++ b/common/src/main/java/hardcorequesting/common/team/TeamAction.java
@@ -91,7 +91,7 @@ public enum TeamAction {
                                 QuestData joinData = team.getQuestData().get(questId);
                                 QuestData questData = inviteTeam.getQuestData().get(questId);
                                 if (questData != null) {
-                                    questData.insertPlayer(id, joinData.canClaimReward(0));
+                                    questData.insertPlayer(id, joinData.canClaimPlayerReward(0));
                                 }
                             }
                             

--- a/common/src/main/java/hardcorequesting/common/team/TeamAction.java
+++ b/common/src/main/java/hardcorequesting/common/team/TeamAction.java
@@ -91,18 +91,7 @@ public enum TeamAction {
                                 QuestData joinData = team.getQuestData().get(questId);
                                 QuestData questData = inviteTeam.getQuestData().get(questId);
                                 if (questData != null) {
-                                    boolean[] old = questData.reward;
-                                    questData.reward = new boolean[old.length + 1];
-                                    for (int j = 0; j < questData.reward.length; j++) {
-                                        if (j == id) {
-                                            questData.reward[j] = joinData.reward[0]; //you keep your reward
-                                        } else if (j < id) {
-                                            questData.reward[j] = old[j];
-                                        } else {
-                                            questData.reward[j] = old[j - 1];
-                                        }
-                                        
-                                    }
+                                    questData.insertPlayer(id, joinData.canClaimReward(0));
                                 }
                             }
                             

--- a/common/src/main/java/hardcorequesting/common/team/TeamUpdateType.java
+++ b/common/src/main/java/hardcorequesting/common/team/TeamUpdateType.java
@@ -56,7 +56,7 @@ public enum TeamUpdateType {
             if (quest != null) {
                 QuestData questData = team.getQuestData(quest.getQuestId());
                 if (questData != null) {
-                    questData.claimed = true;
+                    questData.teamRewardClaimed = true;
                     for (JsonElement element : object.get(REPUTATIONS).getAsJsonArray()) {
                         String id = element.getAsJsonObject().get(ID).getAsString();
                         int val = element.getAsJsonObject().get(VAL).getAsInt();


### PR DESCRIPTION
Changes include:
- Quest data adapter no longer serializes or uses parsed list sizes
- Command rewards are no longer skipped in the presence of a reputation reward
- Probably fixed some missing data sync regarding claimed team rewards