### PR TITLE
Tweaks and features with items and fluids

### DIFF
--- a/common/src/main/java/hardcorequesting/common/client/interfaces/edit/PickItemMenu.java
+++ b/common/src/main/java/hardcorequesting/common/client/interfaces/edit/PickItemMenu.java
@@ -419,9 +419,10 @@ public class PickItemMenu<T> extends GuiEditMenu {
         for (int i = 0; i < itemLength; i++) {
             ItemStack stack = inventory.getItem(i);
             
-            FluidStack fluid = HardcoreQuestingCore.platform.findFluidIn(stack);
-            if (!fluid.isEmpty() && fluids.add(fluid.getFluid())) {
-                playerFluids.add(fluid);
+            for (FluidStack fluid : HardcoreQuestingCore.platform.findFluidsIn(stack)) {
+                if (!fluid.isEmpty() && fluids.add(fluid.getFluid())) {
+                    playerFluids.add(fluid);
+                }
             }
         }
         

--- a/common/src/main/java/hardcorequesting/common/io/adapter/MinecraftAdapter.java
+++ b/common/src/main/java/hardcorequesting/common/io/adapter/MinecraftAdapter.java
@@ -19,11 +19,7 @@ import net.minecraft.world.level.material.Fluid;
  * Created by lang2 on 10/12/2015.
  */
 public class MinecraftAdapter {
-    public static final Adapter<ItemStack> ITEM_STACK = new Adapter<ItemStack>() {
-        private static final String ID = "id";
-        private static final String DAMAGE = "damage";
-        private static final String STACK_SIZE = "amount";
-        private static final String NBT = "nbt";
+    public static final Adapter<ItemStack> ITEM_STACK = new Adapter<>() {
         
         @Override
         public JsonElement serialize(ItemStack src) {
@@ -38,6 +34,26 @@ public class MinecraftAdapter {
             if (json.isJsonNull())
                 return ItemStack.EMPTY;
             return ItemStack.of((CompoundTag) Dynamic.convert(JsonOps.INSTANCE, NbtOps.INSTANCE, json));
+        }
+    };
+    // A more restrictive version of ITEM_STACK that caps stack sizes at 1
+    public static final Adapter<ItemStack> ICON_ITEM_STACK = new Adapter<>() {
+        
+        @Override
+        public JsonElement serialize(ItemStack src) {
+            if (src.getCount() > 1) {
+                src = src.copy();
+                src.setCount(1);
+            }
+            return ITEM_STACK.serialize(src);
+        }
+        
+        @Override
+        public ItemStack deserialize(JsonElement json) {
+            ItemStack stack = ITEM_STACK.deserialize(json);
+            if (stack.getCount() > 1)
+                stack.setCount(1);
+            return stack;
         }
     };
     public static final Adapter<FluidStack> FLUID = new Adapter<FluidStack>() {

--- a/common/src/main/java/hardcorequesting/common/io/adapter/QuestAdapter.java
+++ b/common/src/main/java/hardcorequesting/common/io/adapter/QuestAdapter.java
@@ -171,7 +171,7 @@ public class QuestAdapter {
                     .use(builder -> {
                         if (src.useBigIcon())
                             builder.add(BIG_ICON, true);
-                        src.getIconStack().ifLeft(item -> builder.add(ICON, MinecraftAdapter.ITEM_STACK.serialize(item)));
+                        src.getIconStack().ifLeft(item -> builder.add(ICON, MinecraftAdapter.ICON_ITEM_STACK.serialize(item)));
                         src.getIconStack().ifRight(fluid -> builder.add(FLUID_ICON, MinecraftAdapter.FLUID.serialize(fluid)));
                         if (src.getRepeatInfo().getType() != RepeatType.NONE)
                             builder.add(REPEAT, REPEAT_INFO_ADAPTER.serialize(src.getRepeatInfo()));
@@ -224,7 +224,7 @@ public class QuestAdapter {
             QUEST.setTriggerTasks(GsonHelper.getAsInt(object, TRIGGER_TASKS, QUEST.getTriggerTasks()));
             QUEST.setParentRequirementCount(GsonHelper.getAsInt(object, PARENT_REQUIREMENT, QUEST._getParentRequirementCount()));
             if (object.has(ICON)) {
-                ItemStack icon = MinecraftAdapter.ITEM_STACK.deserialize(object.get(ICON));
+                ItemStack icon = MinecraftAdapter.ICON_ITEM_STACK.deserialize(object.get(ICON));
                 QUEST.setIconStack(Either.left(icon));
             }
             if (object.has(FLUID_ICON)) {

--- a/common/src/main/java/hardcorequesting/common/io/adapter/QuestAdapter.java
+++ b/common/src/main/java/hardcorequesting/common/io/adapter/QuestAdapter.java
@@ -5,7 +5,9 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.reflect.TypeToken;
+import com.mojang.datafixers.util.Either;
 import hardcorequesting.common.io.SaveHandler;
+import hardcorequesting.common.platform.FluidStack;
 import hardcorequesting.common.quests.*;
 import hardcorequesting.common.quests.reward.QuestRewards;
 import hardcorequesting.common.quests.reward.ReputationReward;
@@ -119,6 +121,7 @@ public class QuestAdapter {
         private static final String X = "x";
         private static final String Y = "y";
         private static final String ICON = "icon";
+        private static final String FLUID_ICON = "fluid_icon";
         private static final String BIG_ICON = "bigicon";
         private static final String REQUIREMENTS = "requirements";
         private static final String PREREQUISITES = "prerequisites";
@@ -168,8 +171,8 @@ public class QuestAdapter {
                     .use(builder -> {
                         if (src.useBigIcon())
                             builder.add(BIG_ICON, true);
-                        if (src.getIconStack() != null)
-                            builder.add(ICON, MinecraftAdapter.ITEM_STACK.serialize(src.getIconStack()));
+                        src.getIconStack().ifLeft(item -> builder.add(ICON, MinecraftAdapter.ITEM_STACK.serialize(item)));
+                        src.getIconStack().ifRight(fluid -> builder.add(FLUID_ICON, MinecraftAdapter.FLUID.serialize(fluid)));
                         if (src.getRepeatInfo().getType() != RepeatType.NONE)
                             builder.add(REPEAT, REPEAT_INFO_ADAPTER.serialize(src.getRepeatInfo()));
                         if (src.getTriggerType() != TriggerType.NONE)
@@ -222,9 +225,11 @@ public class QuestAdapter {
             QUEST.setParentRequirementCount(GsonHelper.getAsInt(object, PARENT_REQUIREMENT, QUEST._getParentRequirementCount()));
             if (object.has(ICON)) {
                 ItemStack icon = MinecraftAdapter.ITEM_STACK.deserialize(object.get(ICON));
-                if (!icon.isEmpty()) {
-                    QUEST.setIconStack(icon);
-                }
+                QUEST.setIconStack(Either.left(icon));
+            }
+            if (object.has(FLUID_ICON)) {
+                FluidStack icon = MinecraftAdapter.FLUID.deserialize(object.get(FLUID_ICON));
+                QUEST.setIconStack(Either.right(icon));
             }
             if (object.has(REQUIREMENTS)) requirement = SaveHandler.GSON.fromJson(object.get(REQUIREMENTS), STRING_LIST_TYPE);
             if (object.has(OPTIONS)) options = SaveHandler.GSON.fromJson(object.get(OPTIONS), STRING_LIST_TYPE);

--- a/common/src/main/java/hardcorequesting/common/io/adapter/QuestTaskAdapter.java
+++ b/common/src/main/java/hardcorequesting/common/io/adapter/QuestTaskAdapter.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import com.mojang.datafixers.util.Either;
 import hardcorequesting.common.platform.FluidStack;
 import hardcorequesting.common.quests.ItemPrecision;
 import hardcorequesting.common.quests.data.*;
@@ -114,16 +115,17 @@ public class QuestTaskAdapter {
             return result;
         }
     };
-    public static final Adapter<VisitLocationTask.Part> LOCATION_ADAPTER = new Adapter<VisitLocationTask.Part>() {
+    public static final Adapter<VisitLocationTask.Part> LOCATION_ADAPTER = new Adapter<>() {
         private static final String X = "x";
         private static final String Y = "y";
         private static final String Z = "z";
         private static final String DIM = "dim";
         private static final String ICON = "icon";
+        private static final String FLUID_ICON = "fluid_icon";
         private static final String RADIUS = "radius";
         private static final String VISIBLE = "visible";
         private static final String NAME = "name";
-        
+    
         @Override
         public JsonElement serialize(VisitLocationTask.Part src) {
             return object()
@@ -135,16 +137,14 @@ public class QuestTaskAdapter {
                     .add(RADIUS, src.getRadius())
                     .add(VISIBLE, src.getVisibility().name())
                     .use(builder -> {
-                        ItemStack stack = src.getIconStack();
-                        if (stack != null) {
-                            builder.add(ICON, MinecraftAdapter.ITEM_STACK.serialize(stack));
-                        } else {
-                            builder.add(ICON, MinecraftAdapter.ITEM_STACK.serialize(ItemStack.EMPTY));
-                        }
+                        Optional<ItemStack> item = src.getIconStack().left();
+                        Optional<FluidStack> fluid = src.getIconStack().right();
+                        item.ifPresent(itemStack -> builder.add(ICON, MinecraftAdapter.ITEM_STACK.serialize(itemStack)));
+                        fluid.ifPresent(fluidStack -> builder.add(FLUID_ICON, MinecraftAdapter.FLUID.serialize(fluidStack)));
                     })
                     .build();
         }
-        
+    
         @Override
         public VisitLocationTask.Part deserialize(JsonElement json) {
             JsonObject object = json.getAsJsonObject();
@@ -155,17 +155,20 @@ public class QuestTaskAdapter {
             result.setRadius(GsonHelper.getAsInt(object, RADIUS));
             result.setVisibility(VisitLocationTask.Visibility.valueOf(GsonHelper.getAsString(object, VISIBLE, result.getVisibility().name())));
             if (object.has(ICON)) {
-                result.setIconStack(MinecraftAdapter.ITEM_STACK.deserialize(object.get(ICON)));
+                result.setIconStack(Either.left(MinecraftAdapter.ITEM_STACK.deserialize(object.get(ICON))));
+            }
+            if(object.has(FLUID_ICON)) {
+                result.setIconStack(Either.right(MinecraftAdapter.FLUID.deserialize(object.get(FLUID_ICON))));
             }
             return result;
         }
     };
-    public static final Adapter<ReputationTask.Part> REPUTATION_TASK_ADAPTER = new Adapter<ReputationTask.Part>() {
+    public static final Adapter<ReputationTask.Part> REPUTATION_TASK_ADAPTER = new Adapter<>() {
         private static final String REPUTATION = "reputation";
         private static final String LOWER = "lower";
         private static final String UPPER = "upper";
         private static final String INVERTED = "inverted";
-        
+    
         @Override
         public JsonElement serialize(ReputationTask.Part src) {
             JsonObjectBuilder builder = object()
@@ -177,7 +180,7 @@ public class QuestTaskAdapter {
                 builder.add(UPPER, src.getUpper().getId());
             return builder.build();
         }
-        
+    
         @Override
         public ReputationTask.Part deserialize(JsonElement json) {
             JsonObject object = json.getAsJsonObject();
@@ -196,26 +199,31 @@ public class QuestTaskAdapter {
         }
     };
     
-    public static final TypeAdapter<TameMobsTask.Part> TAME_ADAPTER = new TypeAdapter<TameMobsTask.Part>() {
+    public static final TypeAdapter<TameMobsTask.Part> TAME_ADAPTER = new TypeAdapter<>() {
         private static final String TAMES = "tames";
         private static final String EXACT = "exact";
         private static final String TAME = "tame";
         private static final String ICON = "icon";
+        private static final String FLUID_ICON = "fluid_icon";
         private static final String NAME = "name";
-        
+    
         @Override
         public void write(JsonWriter out, TameMobsTask.Part value) throws IOException {
             out.beginObject();
             out.name(NAME).value(value.getName());
-            ItemStack stack = value.getIconStack();
-            if (stack != null) {
-                MinecraftAdapter.ITEM_STACK.write(out.name(ICON), stack);
+            Optional<ItemStack> item = value.getIconStack().left();
+            Optional<FluidStack> fluid = value.getIconStack().right();
+            if (item.isPresent()) {
+                MinecraftAdapter.ITEM_STACK.write(out.name(ICON), item.get());
+            }
+            if (fluid.isPresent()) {
+                MinecraftAdapter.FLUID.write(out.name(FLUID_ICON), fluid.get());
             }
             out.name(TAME).value(value.getTame());
             out.name(TAMES).value(value.getCount());
             out.endObject();
         }
-        
+    
         @Override
         public TameMobsTask.Part read(JsonReader in) throws IOException {
             in.beginObject();
@@ -226,8 +234,13 @@ public class QuestTaskAdapter {
                     result.setName(in.nextString());
                 } else if (name.equalsIgnoreCase(ICON)) {
                     ItemStack icon = MinecraftAdapter.ITEM_STACK.read(in);
-                    if (!icon.isEmpty()) {
-                        result.setIconStack(icon);
+                    if (icon != null) {
+                        result.setIconStack(Either.left(icon));
+                    }
+                } else if(name.equalsIgnoreCase(FLUID_ICON)) {
+                    FluidStack fluid = MinecraftAdapter.FLUID.read(in);
+                    if (fluid != null) {
+                        result.setIconStack(Either.right(fluid));
                     }
                 } else if (name.equalsIgnoreCase(TAME)) {
                     result.setTame(in.nextString());
@@ -242,6 +255,7 @@ public class QuestTaskAdapter {
     
     public static final TypeAdapter<GetAdvancementTask.Part> ADVANCEMENT_TASK_ADAPTER = new TypeAdapter<GetAdvancementTask.Part>() {
         private final String ICON = "icon";
+        private static final String FLUID_ICON = "fluid_icon";
         private final String VISIBLE = "visible";
         private final String NAME = "name";
         private final String ADV_NAME = "adv_name";
@@ -250,9 +264,13 @@ public class QuestTaskAdapter {
         public void write(JsonWriter out, GetAdvancementTask.Part value) throws IOException {
             out.beginObject();
             out.name(NAME).value(value.getName());
-            ItemStack stack = value.getIconStack();
-            if (stack != null) {
-                MinecraftAdapter.ITEM_STACK.write(out.name(ICON), stack);
+            Optional<ItemStack> item = value.getIconStack().left();
+            Optional<FluidStack> fluid = value.getIconStack().right();
+            if (item.isPresent()) {
+                MinecraftAdapter.ITEM_STACK.write(out.name(ICON), item.get());
+            }
+            if (fluid.isPresent()) {
+                MinecraftAdapter.FLUID.write(out.name(FLUID_ICON), fluid.get());
             }
             if (value.getAdvancement() != null) {
                 out.name(ADV_NAME).value(value.getAdvancement());
@@ -271,7 +289,15 @@ public class QuestTaskAdapter {
                 if (name.equalsIgnoreCase(NAME)) {
                     result.setName(in.nextString());
                 } else if (name.equalsIgnoreCase(ICON)) {
-                    result.setIconStack(MinecraftAdapter.ITEM_STACK.read(in));
+                    ItemStack icon = MinecraftAdapter.ITEM_STACK.read(in);
+                    if (icon != null) {
+                        result.setIconStack(Either.left(icon));
+                    }
+                } else if(name.equalsIgnoreCase(FLUID_ICON)) {
+                    FluidStack fluid = MinecraftAdapter.FLUID.read(in);
+                    if (fluid != null) {
+                        result.setIconStack(Either.right(fluid));
+                    }
                 } else if (name.equalsIgnoreCase(ADV_NAME)) {
                     result.setAdvancement(in.nextString());
                 } else if (name.equalsIgnoreCase(VISIBLE)) {
@@ -311,27 +337,28 @@ public class QuestTaskAdapter {
         }
     };
     
-    public static final Adapter<KillMobsTask.Part> MOB_ADAPTER = new Adapter<KillMobsTask.Part>() {
+    public static final Adapter<KillMobsTask.Part> MOB_ADAPTER = new Adapter<>() {
         private static final String KILLS = "kills";
         private static final String MOB = "mob";
         private static final String ICON = "icon";
+        private static final String FLUID_ICON = "fluid_icon";
         private static final String NAME = "name";
-        
+    
         @Override
         public JsonElement serialize(KillMobsTask.Part src) {
             return object()
                     .add(NAME, src.getName())
                     .use(builder -> {
-                        ItemStack stack = src.getIconStack();
-                        if (stack != null) {
-                            builder.add(ICON, MinecraftAdapter.ITEM_STACK.toJsonTree(stack));
-                        }
+                        Optional<ItemStack> item = src.getIconStack().left();
+                        Optional<FluidStack> fluid = src.getIconStack().right();
+                        item.ifPresent(itemStack -> builder.add(ICON, MinecraftAdapter.ITEM_STACK.toJsonTree(itemStack)));
+                        fluid.ifPresent(fluidStack -> builder.add(FLUID_ICON, MinecraftAdapter.FLUID.toJsonTree(fluidStack)));
                     })
                     .add(MOB, src.getMob().toString())
                     .add(KILLS, src.getCount())
                     .build();
         }
-        
+    
         @Override
         public KillMobsTask.Part deserialize(JsonElement json) {
             JsonObject object = json.getAsJsonObject();
@@ -341,23 +368,25 @@ public class QuestTaskAdapter {
             result.setCount(GsonHelper.getAsInt(object, KILLS, result.getCount()));
             if (object.has(ICON)) {
                 ItemStack icon = MinecraftAdapter.ITEM_STACK.deserialize(GsonHelper.getAsJsonObject(object, ICON));
-                if (!icon.isEmpty()) {
-                    result.setIconStack(icon);
-                }
+                result.setIconStack(Either.left(icon));
+            }
+            if(object.has(FLUID_ICON)) {
+                FluidStack fluid = MinecraftAdapter.FLUID.deserialize(GsonHelper.getAsJsonObject(object, FLUID_ICON));
+                result.setIconStack(Either.right(fluid));
             }
             return result;
         }
     };
     public static Map<ReputationTask<?>, List<ReputationSettingConstructor>> taskReputationListMap = new HashMap<>();
-    protected static final Adapter<QuestTask<?>> TASK_ADAPTER = new Adapter<QuestTask<?>>() {
+    protected static final Adapter<QuestTask<?>> TASK_ADAPTER = new Adapter<>() {
         private static final String TYPE = "type";
         private static final String DESCRIPTION = "description";
         private static final String LONG_DESCRIPTION = "longDescription";
-        
+    
         @Override
         public JsonElement serialize(QuestTask<?> src) {
             TaskType type = TaskType.getType(src.getClass());
-            
+        
             JsonObjectBuilder builder = object()
                     .add(TYPE, type.name());
             if (!src.getDescription().equals(type.getName()))
@@ -367,7 +396,7 @@ public class QuestTaskAdapter {
             src.write(builder);
             return builder.build();
         }
-        
+    
         @Override
         public QuestTask<?> deserialize(JsonElement json) {
             JsonObject object = json.getAsJsonObject();

--- a/common/src/main/java/hardcorequesting/common/io/adapter/QuestTaskAdapter.java
+++ b/common/src/main/java/hardcorequesting/common/io/adapter/QuestTaskAdapter.java
@@ -26,10 +26,7 @@ import net.minecraft.util.GsonHelper;
 import net.minecraft.world.item.ItemStack;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.function.Function;
 
 import static hardcorequesting.common.io.adapter.QuestAdapter.QUEST;
@@ -61,15 +58,15 @@ public class QuestTaskAdapter {
         
         @Override
         public void write(JsonWriter out, ItemRequirementTask.Part value) throws IOException {
-            ItemStack stack = value.getStack();
-            FluidStack fluid = value.fluid;
+            Optional<ItemStack> stack = value.stack.left();
+            Optional<FluidStack> fluid = value.stack.right();
             int required = value.required;
             ItemPrecision precision = value.getPrecision();
             out.beginObject();
-            if (value.hasItem && !stack.isEmpty()) {
-                MinecraftAdapter.ITEM_STACK.write(out.name(ITEM), stack);
-            } else if (fluid != null) {
-                MinecraftAdapter.FLUID.write(out.name(FLUID), fluid);
+            if (stack.isPresent()) {
+                MinecraftAdapter.ITEM_STACK.write(out.name(ITEM), stack.get());
+            } else if (fluid.isPresent()) {
+                MinecraftAdapter.FLUID.write(out.name(FLUID), fluid.get());
             } else {
                 out.nullValue();
                 out.endObject();

--- a/common/src/main/java/hardcorequesting/common/io/adapter/QuestTaskAdapter.java
+++ b/common/src/main/java/hardcorequesting/common/io/adapter/QuestTaskAdapter.java
@@ -65,7 +65,9 @@ public class QuestTaskAdapter {
             ItemPrecision precision = value.getPrecision();
             out.beginObject();
             if (stack.isPresent()) {
-                MinecraftAdapter.ITEM_STACK.write(out.name(ITEM), stack.get());
+                // Item stack count doesn't track task requirement; "required" does that.
+                // So we are fine to keep the stack count at 1.
+                MinecraftAdapter.ICON_ITEM_STACK.write(out.name(ITEM), stack.get());
             } else if (fluid.isPresent()) {
                 MinecraftAdapter.FLUID.write(out.name(FLUID), fluid.get());
             } else {
@@ -90,7 +92,7 @@ public class QuestTaskAdapter {
             while (in.hasNext()) {
                 String next = in.nextName();
                 if (next.equalsIgnoreCase(ITEM)) {
-                    itemStack = MinecraftAdapter.ITEM_STACK.read(in);
+                    itemStack = MinecraftAdapter.ICON_ITEM_STACK.read(in);
                 } else if (next.equalsIgnoreCase(FLUID)) {
                     fluidVolume = MinecraftAdapter.FLUID.read(in);
                 } else if (next.equalsIgnoreCase(REQUIRED)) {
@@ -139,7 +141,7 @@ public class QuestTaskAdapter {
                     .use(builder -> {
                         Optional<ItemStack> item = src.getIconStack().left();
                         Optional<FluidStack> fluid = src.getIconStack().right();
-                        item.ifPresent(itemStack -> builder.add(ICON, MinecraftAdapter.ITEM_STACK.serialize(itemStack)));
+                        item.ifPresent(itemStack -> builder.add(ICON, MinecraftAdapter.ICON_ITEM_STACK.serialize(itemStack)));
                         fluid.ifPresent(fluidStack -> builder.add(FLUID_ICON, MinecraftAdapter.FLUID.serialize(fluidStack)));
                     })
                     .build();
@@ -155,7 +157,7 @@ public class QuestTaskAdapter {
             result.setRadius(GsonHelper.getAsInt(object, RADIUS));
             result.setVisibility(VisitLocationTask.Visibility.valueOf(GsonHelper.getAsString(object, VISIBLE, result.getVisibility().name())));
             if (object.has(ICON)) {
-                result.setIconStack(Either.left(MinecraftAdapter.ITEM_STACK.deserialize(object.get(ICON))));
+                result.setIconStack(Either.left(MinecraftAdapter.ICON_ITEM_STACK.deserialize(object.get(ICON))));
             }
             if(object.has(FLUID_ICON)) {
                 result.setIconStack(Either.right(MinecraftAdapter.FLUID.deserialize(object.get(FLUID_ICON))));
@@ -214,7 +216,7 @@ public class QuestTaskAdapter {
             Optional<ItemStack> item = value.getIconStack().left();
             Optional<FluidStack> fluid = value.getIconStack().right();
             if (item.isPresent()) {
-                MinecraftAdapter.ITEM_STACK.write(out.name(ICON), item.get());
+                MinecraftAdapter.ICON_ITEM_STACK.write(out.name(ICON), item.get());
             }
             if (fluid.isPresent()) {
                 MinecraftAdapter.FLUID.write(out.name(FLUID_ICON), fluid.get());
@@ -233,7 +235,7 @@ public class QuestTaskAdapter {
                 if (name.equalsIgnoreCase(NAME)) {
                     result.setName(in.nextString());
                 } else if (name.equalsIgnoreCase(ICON)) {
-                    ItemStack icon = MinecraftAdapter.ITEM_STACK.read(in);
+                    ItemStack icon = MinecraftAdapter.ICON_ITEM_STACK.read(in);
                     if (icon != null) {
                         result.setIconStack(Either.left(icon));
                     }
@@ -253,13 +255,13 @@ public class QuestTaskAdapter {
         }
     };
     
-    public static final TypeAdapter<GetAdvancementTask.Part> ADVANCEMENT_TASK_ADAPTER = new TypeAdapter<GetAdvancementTask.Part>() {
+    public static final TypeAdapter<GetAdvancementTask.Part> ADVANCEMENT_TASK_ADAPTER = new TypeAdapter<>() {
         private final String ICON = "icon";
         private static final String FLUID_ICON = "fluid_icon";
         private final String VISIBLE = "visible";
         private final String NAME = "name";
         private final String ADV_NAME = "adv_name";
-        
+    
         @Override
         public void write(JsonWriter out, GetAdvancementTask.Part value) throws IOException {
             out.beginObject();
@@ -267,7 +269,7 @@ public class QuestTaskAdapter {
             Optional<ItemStack> item = value.getIconStack().left();
             Optional<FluidStack> fluid = value.getIconStack().right();
             if (item.isPresent()) {
-                MinecraftAdapter.ITEM_STACK.write(out.name(ICON), item.get());
+                MinecraftAdapter.ICON_ITEM_STACK.write(out.name(ICON), item.get());
             }
             if (fluid.isPresent()) {
                 MinecraftAdapter.FLUID.write(out.name(FLUID_ICON), fluid.get());
@@ -279,7 +281,7 @@ public class QuestTaskAdapter {
                 out.name(VISIBLE).value(value.getVisible().name());
             out.endObject();
         }
-        
+    
         @Override
         public GetAdvancementTask.Part read(JsonReader in) throws IOException {
             in.beginObject();
@@ -289,11 +291,11 @@ public class QuestTaskAdapter {
                 if (name.equalsIgnoreCase(NAME)) {
                     result.setName(in.nextString());
                 } else if (name.equalsIgnoreCase(ICON)) {
-                    ItemStack icon = MinecraftAdapter.ITEM_STACK.read(in);
+                    ItemStack icon = MinecraftAdapter.ICON_ITEM_STACK.read(in);
                     if (icon != null) {
                         result.setIconStack(Either.left(icon));
                     }
-                } else if(name.equalsIgnoreCase(FLUID_ICON)) {
+                } else if (name.equalsIgnoreCase(FLUID_ICON)) {
                     FluidStack fluid = MinecraftAdapter.FLUID.read(in);
                     if (fluid != null) {
                         result.setIconStack(Either.right(fluid));
@@ -351,7 +353,7 @@ public class QuestTaskAdapter {
                     .use(builder -> {
                         Optional<ItemStack> item = src.getIconStack().left();
                         Optional<FluidStack> fluid = src.getIconStack().right();
-                        item.ifPresent(itemStack -> builder.add(ICON, MinecraftAdapter.ITEM_STACK.toJsonTree(itemStack)));
+                        item.ifPresent(itemStack -> builder.add(ICON, MinecraftAdapter.ICON_ITEM_STACK.toJsonTree(itemStack)));
                         fluid.ifPresent(fluidStack -> builder.add(FLUID_ICON, MinecraftAdapter.FLUID.toJsonTree(fluidStack)));
                     })
                     .add(MOB, src.getMob().toString())
@@ -367,7 +369,7 @@ public class QuestTaskAdapter {
             result.setMob(new ResourceLocation(GsonHelper.getAsString(object, MOB, result.getMob().toString())));
             result.setCount(GsonHelper.getAsInt(object, KILLS, result.getCount()));
             if (object.has(ICON)) {
-                ItemStack icon = MinecraftAdapter.ITEM_STACK.deserialize(GsonHelper.getAsJsonObject(object, ICON));
+                ItemStack icon = MinecraftAdapter.ICON_ITEM_STACK.deserialize(GsonHelper.getAsJsonObject(object, ICON));
                 result.setIconStack(Either.left(icon));
             }
             if(object.has(FLUID_ICON)) {

--- a/common/src/main/java/hardcorequesting/common/platform/AbstractPlatform.java
+++ b/common/src/main/java/hardcorequesting/common/platform/AbstractPlatform.java
@@ -37,6 +37,7 @@ import net.minecraft.world.level.material.Fluid;
 import org.apache.logging.log4j.util.TriConsumer;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -121,11 +122,10 @@ public interface AbstractPlatform {
     FluidStack createFluidStack(Fluid fluid, Fraction amount);
     
     /**
-     * Obtains the fluid contained in the item stack.
-     * If there is no fluid in the item stack, an empty fluid stack will be returned.
-     * Only the fluid type is guaranteed to match. The amount returned might not match the amount in the item stack.
+     * Obtains any fluids contained in the item stack.
+     * If there is no fluid in the item stack, an empty list will be returned.
      */
-    FluidStack findFluidIn(ItemStack stack);
+    List<FluidStack> findFluidsIn(ItemStack stack);
     
     @Environment(EnvType.CLIENT)
     void renderFluidStack(FluidStack fluid, PoseStack stack, int x1, int y1, int x2, int y2);

--- a/common/src/main/java/hardcorequesting/common/quests/Quest.java
+++ b/common/src/main/java/hardcorequesting/common/quests/Quest.java
@@ -2,6 +2,7 @@ package hardcorequesting.common.quests;
 
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.datafixers.util.Either;
 import hardcorequesting.common.HardcoreQuestingCore;
 import hardcorequesting.common.client.ClientChange;
 import hardcorequesting.common.client.EditMode;
@@ -14,6 +15,7 @@ import hardcorequesting.common.network.GeneralUsage;
 import hardcorequesting.common.network.IMessage;
 import hardcorequesting.common.network.NetworkManager;
 import hardcorequesting.common.network.message.QuestDataUpdateMessage;
+import hardcorequesting.common.platform.FluidStack;
 import hardcorequesting.common.quests.data.QuestData;
 import hardcorequesting.common.quests.reward.QuestRewards;
 import hardcorequesting.common.quests.task.DeathTask;
@@ -84,7 +86,7 @@ public class Quest {
     private int x;
     private int y;
     private boolean isBig;
-    private ItemStack iconStack = ItemStack.EMPTY;
+    private Either<ItemStack, FluidStack> iconStack = Either.left(ItemStack.EMPTY);
     private QuestSet set;
     private ParentEvaluator enabledParentEvaluator = new ParentEvaluator() {
         @Override
@@ -610,15 +612,12 @@ public class Quest {
         this.y = y - getGuiH() / 2;
     }
     
-    public ItemStack getIconStack() {
+    public Either<ItemStack, FluidStack> getIconStack() {
         return iconStack;
     }
     
-    public void setIconStack(ItemStack iconStack) {
+    public void setIconStack(Either<ItemStack, FluidStack> iconStack) {
         this.iconStack = iconStack;
-        if (iconStack != null) {
-            iconStack.setCount(1);
-        }
     }
     //endregion
     

--- a/common/src/main/java/hardcorequesting/common/quests/Quest.java
+++ b/common/src/main/java/hardcorequesting/common/quests/Quest.java
@@ -619,6 +619,27 @@ public class Quest {
     public void setIconStack(Either<ItemStack, FluidStack> iconStack) {
         this.iconStack = iconStack;
     }
+    
+    public void setIconIfEmpty(ItemStack stack) {
+        if (!stack.isEmpty()) {
+            stack = stack.copy();
+            stack.setCount(1);
+            setIconIfEmpty(Either.left(stack));
+        }
+    }
+    
+    public void setIconIfEmpty(FluidStack stack) {
+        if (!stack.isEmpty())
+            setIconIfEmpty(Either.right(stack));
+    }
+    
+    public void setIconIfEmpty(Either<ItemStack, FluidStack> iconStack) {
+        if (this.iconStack.map(ItemStack::isEmpty, FluidStack::isEmpty)) {
+            setIconStack(iconStack);
+            SaveHelper.add(EditType.ICON_CHANGE);
+        }
+    }
+    
     //endregion
     
     public boolean useBigIcon() {

--- a/common/src/main/java/hardcorequesting/common/quests/QuestSet.java
+++ b/common/src/main/java/hardcorequesting/common/quests/QuestSet.java
@@ -758,7 +758,9 @@ public class QuestSet {
                     iconY++;
                 }
                 
-                gui.drawItemStack(quest.getIconStack(), iconX, iconY, true);
+                final int iconX_ = iconX, iconY_ = iconY;
+                quest.getIconStack().ifLeft(itemStack -> gui.drawItemStack(itemStack, iconX_, iconY_, true))
+                        .ifRight(fluidStack -> gui.drawFluid(fluidStack, matrices, iconX_, iconY_));
                 //ResourceHelper.bindResource(QUEST_ICONS);
                 //drawRect(quest.getIconX(), quest.getIconY(), quest.getIconU(), quest.getIconV(), quest.getIconSize(), quest.getIconSize());
             }
@@ -816,7 +818,7 @@ public class QuestSet {
                                 SaveHelper.add(EditType.QUEST_SIZE_CHANGE);
                                 break;
                             case ITEM:
-                                PickItemMenu.display(gui, player, quest.getIconStack(), PickItemMenu.Type.ITEM,
+                                PickItemMenu.display(gui, player, quest.getIconStack(), PickItemMenu.Type.ITEM_FLUID,
                                         result -> {
                                             try {
                                                 quest.setIconStack(result.get());

--- a/common/src/main/java/hardcorequesting/common/quests/reward/QuestRewards.java
+++ b/common/src/main/java/hardcorequesting/common/quests/reward/QuestRewards.java
@@ -217,6 +217,7 @@ public class QuestRewards {
             SaveHelper.add(EditType.REWARD_CREATE);
             rewardList.add(stack);
         }
+        quest.setIconIfEmpty(stack);
     }
     
     @Environment(EnvType.CLIENT)

--- a/common/src/main/java/hardcorequesting/common/quests/task/CompleteQuestTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/CompleteQuestTask.java
@@ -2,9 +2,11 @@ package hardcorequesting.common.quests.task;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import com.mojang.datafixers.util.Either;
 import hardcorequesting.common.event.EventTrigger;
 import hardcorequesting.common.io.adapter.Adapter;
 import hardcorequesting.common.io.adapter.QuestTaskAdapter;
+import hardcorequesting.common.platform.FluidStack;
 import hardcorequesting.common.quests.Quest;
 import hardcorequesting.common.quests.data.CompleteQuestTaskData;
 import hardcorequesting.common.quests.task.client.CompleteQuestTaskGraphic;
@@ -145,9 +147,9 @@ public class CompleteQuestTask extends QuestTask<CompleteQuestTaskData> {
     public static class Part {
         private UUID quest_id;
     
-        public ItemStack getIconStack() {
+        public Either<ItemStack, FluidStack> getIconStack() {
             Quest q = getQuest();
-            return (q != null) ? q.getIconStack() : ItemStack.EMPTY;
+            return (q != null) ? q.getIconStack() : Either.left(ItemStack.EMPTY);
         }
         
         public String getName() {

--- a/common/src/main/java/hardcorequesting/common/quests/task/client/CompleteQuestTaskGraphic.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/client/CompleteQuestTaskGraphic.java
@@ -48,7 +48,9 @@ public class CompleteQuestTaskGraphic extends ListTaskGraphic<CompleteQuestTask.
     
     @Override
     protected List<FormattedText> drawPart(PoseStack matrices, GuiQuestBook gui, Player player, CompleteQuestTask.Part part, int id, int x, int y, int mX, int mY) {
-        gui.drawItemStack(matrices, part.getIconStack(), x, y, mX, mY, false);
+        part.getIconStack().ifLeft(itemStack -> gui.drawItemStack(matrices, itemStack, x, y, mX, mY, false))
+                .ifRight(fluidStack -> gui.drawFluid(fluidStack, matrices, x, y, mX, mY));
+        
         if (part.getQuest() != null) {
             gui.drawString(matrices, Translator.plain(part.getName()), x + X_TEXT_OFFSET, y + Y_TEXT_OFFSET, 0x404040);
             if (task.completed(id, player)) {

--- a/common/src/main/java/hardcorequesting/common/quests/task/client/IconTaskGraphic.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/client/IconTaskGraphic.java
@@ -49,8 +49,9 @@ public abstract class IconTaskGraphic<Part extends IconLayoutTask.Part> extends 
     @Override
     protected List<FormattedText> drawPart(PoseStack matrices, GuiQuestBook gui, Player player, Part part, int id, int x, int y, int mX, int mY) {
         int textX = x + X_TEXT_OFFSET, textY = y + Y_TEXT_OFFSET;
-    
-        gui.drawItemStack(matrices, part.getIconStack(), x, y, mX, mY, false);
+        part.getIconStack().ifLeft(itemStack -> gui.drawItemStack(matrices, itemStack, x, y, mX, mY, false))
+                .ifRight(fluidStack -> gui.drawFluid(fluidStack, matrices, x, y, mX, mY));
+        
         gui.drawString(matrices, Translator.plain(part.getName()), textX, textY, 0x404040);
         drawElementText(matrices, gui, player, part, id, textX + X_TEXT_INDENT, textY + 9);
         return null;
@@ -59,7 +60,7 @@ public abstract class IconTaskGraphic<Part extends IconLayoutTask.Part> extends 
     @Override
     protected boolean handlePartClick(GuiQuestBook gui, Player player, EditMode mode, Part part, int id) {
         if (mode == EditMode.ITEM) {
-            PickItemMenu.display(gui, player, part.getIconStack(), PickItemMenu.Type.ITEM,
+            PickItemMenu.display(gui, player, part.getIconStack(), PickItemMenu.Type.ITEM_FLUID,
                     result -> task.setIcon(id, result.get()));
             return true;
         } else if (mode == EditMode.RENAME) {

--- a/common/src/main/java/hardcorequesting/common/quests/task/icon/IconLayoutTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/icon/IconLayoutTask.java
@@ -1,5 +1,7 @@
 package hardcorequesting.common.quests.task.icon;
 
+import com.mojang.datafixers.util.Either;
+import hardcorequesting.common.platform.FluidStack;
 import hardcorequesting.common.quests.Quest;
 import hardcorequesting.common.quests.data.TaskData;
 import hardcorequesting.common.quests.task.PartList;
@@ -26,7 +28,7 @@ public abstract class IconLayoutTask<T extends IconLayoutTask.Part, Data extends
     
     protected abstract T createEmpty();
     
-    public void setIcon(int id, ItemStack stack) {
+    public void setIcon(int id, Either<ItemStack, FluidStack> stack) {
         parts.getOrCreateForModify(id).setIconStack(stack);
     }
     
@@ -35,14 +37,18 @@ public abstract class IconLayoutTask<T extends IconLayoutTask.Part, Data extends
     }
     
     public abstract static class Part {
-        private ItemStack iconStack = ItemStack.EMPTY;
+        private Either<ItemStack, FluidStack> iconStack = Either.left(ItemStack.EMPTY);
         private String name = "New";
         
-        public ItemStack getIconStack() {
+        public Either<ItemStack, FluidStack> getIconStack() {
             return iconStack;
         }
-    
-        public void setIconStack(@NotNull ItemStack iconStack) {
+        
+        public boolean hasNoIcon() {
+            return iconStack.map(ItemStack::isEmpty, FluidStack::isEmpty);
+        }
+        
+        public void setIconStack(@NotNull Either<ItemStack, FluidStack> iconStack) {
             this.iconStack = iconStack;
         }
     

--- a/common/src/main/java/hardcorequesting/common/quests/task/icon/IconLayoutTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/icon/IconLayoutTask.java
@@ -30,6 +30,7 @@ public abstract class IconLayoutTask<T extends IconLayoutTask.Part, Data extends
     
     public void setIcon(int id, Either<ItemStack, FluidStack> stack) {
         parts.getOrCreateForModify(id).setIconStack(stack);
+        parent.setIconIfEmpty(stack);
     }
     
     public void setName(int id, String str) {

--- a/common/src/main/java/hardcorequesting/common/quests/task/icon/TameMobsTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/icon/TameMobsTask.java
@@ -64,6 +64,7 @@ public class TameMobsTask extends IconLayoutTask<TameMobsTask.Part, TameTaskData
                 Item egg = SpawnEggItem.byId(entityType);
                 if(egg != null) {
                     part.setIconStack(Either.left(new ItemStack(egg)));
+                    parent.setIconIfEmpty(new ItemStack(egg));
                 }
             }
         }

--- a/common/src/main/java/hardcorequesting/common/quests/task/icon/TameMobsTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/icon/TameMobsTask.java
@@ -2,6 +2,7 @@ package hardcorequesting.common.quests.task.icon;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import com.mojang.datafixers.util.Either;
 import hardcorequesting.common.event.EventTrigger;
 import hardcorequesting.common.io.adapter.Adapter;
 import hardcorequesting.common.io.adapter.QuestTaskAdapter;
@@ -57,12 +58,12 @@ public class TameMobsTask extends IconLayoutTask<TameMobsTask.Part, TameTaskData
         part.setTame(entityId);
         part.setCount(amount);
         
-        if(entityId != null && (part.getIconStack().isEmpty() || part.getIconStack().getItem() instanceof SpawnEggItem)) {
+        if(entityId != null && (part.hasNoIcon() || part.getIconStack().left().orElse(ItemStack.EMPTY).getItem() instanceof SpawnEggItem)) {
             EntityType<?> entityType = Registry.ENTITY_TYPE.get(new ResourceLocation(entityId));
             if(entityType != null) {
                 Item egg = SpawnEggItem.byId(entityType);
                 if(egg != null) {
-                    part.setIconStack(new ItemStack(egg));
+                    part.setIconStack(Either.left(new ItemStack(egg)));
                 }
             }
         }

--- a/common/src/main/java/hardcorequesting/common/quests/task/item/ConsumeItemTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/item/ConsumeItemTask.java
@@ -24,11 +24,11 @@ public class ConsumeItemTask extends ItemRequirementTask {
         
         for (int i = 0; i < parts.size(); i++) {
             Part item = parts.get(i);
-            if (item.fluid == null || data.isDone(i, item)) {
+            if (data.isDone(i, item)) {
                 continue;
             }
             
-            if (fluidVolume != null && fluidVolume.getFluid() != null && fluidVolume.getFluid() == item.fluid.getFluid()) {
+            if (fluidVolume != null && item.isFluid(fluidVolume.getFluid())) {
                 Fraction amount = fluidVolume.getAmount().isLessThan(Fraction.ofWhole(item.required - data.getValue(i))) ? fluidVolume.getAmount() : Fraction.ofWhole(item.required - data.getValue(i));
                 if (action)
                     data.setValue(i, data.getValue(i) + amount.intValue());
@@ -50,8 +50,7 @@ public class ConsumeItemTask extends ItemRequirementTask {
         ItemsTaskData data = getData(playerId);
         for (int i = 0; i < parts.size(); i++) {
             ItemRequirementTask.Part part = parts.get(i);
-            if (part.hasItem && part.getPrecision().areItemsSame(part.getStack(), stack)
-                    && !data.isDone(i, part)) {
+            if (part.isStack(stack) && !data.isDone(i, part)) {
                 return true;
             }
         }
@@ -62,8 +61,7 @@ public class ConsumeItemTask extends ItemRequirementTask {
         ItemsTaskData data = getData(playerId);
         for (int i = 0; i < parts.size(); i++) {
             ItemRequirementTask.Part part = parts.get(i);
-            if (part.fluid != null && fluid == part.fluid.getFluid()
-                    && !data.isDone(i, part)) {
+            if (part.isFluid(fluid) && !data.isDone(i, part)) {
                 return true;
             }
         }

--- a/common/src/main/java/hardcorequesting/common/quests/task/item/DetectItemTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/item/DetectItemTask.java
@@ -1,6 +1,8 @@
 package hardcorequesting.common.quests.task.item;
 
+import hardcorequesting.common.HardcoreQuestingCore;
 import hardcorequesting.common.event.EventTrigger;
+import hardcorequesting.common.platform.FluidStack;
 import hardcorequesting.common.quests.Quest;
 import hardcorequesting.common.quests.data.ItemsTaskData;
 import net.fabricmc.api.EnvType;
@@ -23,7 +25,7 @@ public class DetectItemTask extends ItemRequirementTask {
     @Environment(EnvType.CLIENT)
     @Override
     public boolean mayUseFluids() {
-        return false;   //TODO we could probably include fluids if we check items for fluid content
+        return true;
     }
     
     @Override
@@ -89,16 +91,25 @@ public class DetectItemTask extends ItemRequirementTask {
         boolean updated = false;
         
         for (int i = 0; i < parts.size(); i++) {
-            Part item = parts.get(i);
-            if (!item.hasItem() || data.isDone(i, item)) {
+            Part part = parts.get(i);
+            if (data.isDone(i, part)) {
                 continue;
             }
             
             for (ItemStack stack : itemsToCount) {
-                if (item.isStack(stack)) {
-                    int amount = Math.min(stack.getCount(), item.required - data.getValue(i));
+                if (part.isStack(stack)) {
+                    int amount = Math.min(stack.getCount(), part.required - data.getValue(i));
                     data.setValue(i, data.getValue(i) + amount);
                     updated = true;
+                }
+                if (!part.hasItem()) {
+                    for (FluidStack fluidStack : HardcoreQuestingCore.platform.findFluidsIn(stack)) {
+                        if (part.isFluid(fluidStack.getFluid())) {
+                            int amount = Math.min(fluidStack.getAmount().intValue(), part.required - data.getValue(i));
+                            data.setValue(i, data.getValue(i) + amount);
+                            updated = true;
+                        }
+                    }
                 }
             }
         }

--- a/common/src/main/java/hardcorequesting/common/quests/task/item/DetectItemTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/item/DetectItemTask.java
@@ -90,12 +90,12 @@ public class DetectItemTask extends ItemRequirementTask {
         
         for (int i = 0; i < parts.size(); i++) {
             Part item = parts.get(i);
-            if (!item.hasItem || data.isDone(i, item)) {
+            if (!item.hasItem() || data.isDone(i, item)) {
                 continue;
             }
             
             for (ItemStack stack : itemsToCount) {
-                if (item.getPrecision().areItemsSame(stack, item.getStack())) {
+                if (item.isStack(stack)) {
                     int amount = Math.min(stack.getCount(), item.required - data.getValue(i));
                     data.setValue(i, data.getValue(i) + amount);
                     updated = true;

--- a/common/src/main/java/hardcorequesting/common/quests/task/item/ItemRequirementTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/item/ItemRequirementTask.java
@@ -22,6 +22,7 @@ import net.minecraft.core.NonNullList;
 import net.minecraft.util.GsonHelper;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.material.Fluid;
 
 import java.util.UUID;
 
@@ -59,15 +60,7 @@ public abstract class ItemRequirementTask extends QuestTask<ItemsTaskData> {
         
         Part requirement = parts.getOrCreateForModify(id);
     
-        item.ifLeft(itemStack -> {
-            requirement.hasItem = true;
-            requirement.fluid = null;
-            requirement.stack = itemStack;
-        }).ifRight(fluidStack -> {
-            requirement.hasItem = false;
-            requirement.fluid = fluidStack;
-            requirement.stack = null;
-        });
+        requirement.stack = item;
         requirement.required = amount;
         requirement.precision = precision;
         requirement.permutations = null;
@@ -93,13 +86,13 @@ public abstract class ItemRequirementTask extends QuestTask<ItemsTaskData> {
         
         for (int i = 0; i < parts.size(); i++) {
             Part item = parts.get(i);
-            if (!item.hasItem || data.isDone(i, item)) {
+            if (!item.hasItem() || data.isDone(i, item)) {
                 continue;
             }
             
             for (int j = 0; j < itemsToConsume.size(); j++) {
                 ItemStack stack = itemsToConsume.get(j);
-                if (item.precision.areItemsSame(stack, item.stack)) {
+                if (item.isStack(stack)) {
                     int amount = Math.min(stack.getCount(), item.required - data.getValue(i));
                     if (amount > 0) {
                         stack.shrink(amount);
@@ -204,10 +197,9 @@ public abstract class ItemRequirementTask extends QuestTask<ItemsTaskData> {
     
     public static class Part {
         private static int CYCLE_TIME = 2;//2 second cycle
-        public FluidStack fluid;
+        
+        public Either<ItemStack, FluidStack> stack;
         public int required;
-        public boolean hasItem;
-        private ItemStack stack = ItemStack.EMPTY;
         private ItemPrecision precision = ItemPrecision.PRECISE;
         private ItemStack[] permutations;
         private int cycleAt = -1;
@@ -219,15 +211,13 @@ public abstract class ItemRequirementTask extends QuestTask<ItemsTaskData> {
         }
         
         public Part(ItemStack stack, int required) {
-            this.stack = stack;
+            this.stack = Either.left(stack);
             this.required = required;
-            this.hasItem = true;
         }
         
         public Part(FluidStack fluid, int required) {
-            this.fluid = fluid;
+            this.stack = Either.right(fluid);
             this.required = required;
-            this.hasItem = false;
         }
         
         public ItemPrecision getPrecision() {
@@ -239,29 +229,42 @@ public abstract class ItemRequirementTask extends QuestTask<ItemsTaskData> {
             permutations = null;
         }
         
+        public boolean hasItem() {
+            return stack.left().isPresent();
+        }
+        
         public ItemStack getStack() {
-            return stack;
+            return stack.left().orElse(ItemStack.EMPTY);
+        }
+        
+        public boolean isStack(ItemStack otherStack) {
+            return stack.left().map(itemStack -> getPrecision().areItemsSame(itemStack, otherStack)).orElse(false);
+        }
+        
+        public boolean isFluid(Fluid fluid) {
+            return stack.right().map(fluidStack -> fluidStack.getFluid() == fluid).orElse(false);
         }
         
         public void setStack(ItemStack stack) {
-            this.stack = stack;
+            this.stack = Either.left(stack);
             this.permutations = null;
         }
         
         private void setPermutations() {
-            if (stack == null) return;
-            permutations = precision.getPermutations(stack);
-            if (permutations != null && permutations.length > 0) {
-                last = permutations.length - 1;
-                cycleAt = -1;
-            }
+            stack.ifLeft(itemStack -> {
+                permutations = precision.getPermutations(itemStack);
+                if (permutations != null && permutations.length > 0) {
+                    last = permutations.length - 1;
+                    cycleAt = -1;
+                }
+            });
         }
         
         public ItemStack getPermutatedItem() {
             if (permutations == null && precision.hasPermutations())
                 setPermutations();
             if (permutations == null || permutations.length < 2)
-                return stack != null ? stack : ItemStack.EMPTY;
+                return stack.left().orElse(ItemStack.EMPTY);
             int ticks = (int) (System.currentTimeMillis() / 1000);
             if (cycleAt == -1)
                 cycleAt = ticks + CYCLE_TIME;

--- a/common/src/main/java/hardcorequesting/common/quests/task/item/ItemRequirementTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/item/ItemRequirementTask.java
@@ -56,14 +56,16 @@ public abstract class ItemRequirementTask extends QuestTask<ItemsTaskData> {
     }
     
     @Environment(EnvType.CLIENT)
-    public void setItem(Either<ItemStack, FluidStack> item, int amount, ItemPrecision precision, int id) {
+    public void setItem(Either<ItemStack, FluidStack> stack, int amount, ItemPrecision precision, int id) {
         
         Part requirement = parts.getOrCreateForModify(id);
     
-        requirement.stack = item;
+        requirement.stack = stack;
         requirement.required = amount;
         requirement.precision = precision;
         requirement.permutations = null;
+        
+        parent.setIconIfEmpty(stack);
     }
     
     public int getProgress(Player player, int id) {

--- a/fabric/src/main/java/hardcorequesting/fabric/HardcoreQuestingFabric.java
+++ b/fabric/src/main/java/hardcorequesting/fabric/HardcoreQuestingFabric.java
@@ -1,7 +1,8 @@
 package hardcorequesting.fabric;
 
-import alexiil.mc.lib.attributes.fluid.FluidItemUtil;
+import alexiil.mc.lib.attributes.fluid.FluidAttributes;
 import alexiil.mc.lib.attributes.fluid.FluidVolumeUtil;
+import alexiil.mc.lib.attributes.fluid.GroupedFluidInvView;
 import alexiil.mc.lib.attributes.fluid.amount.FluidAmount;
 import alexiil.mc.lib.attributes.fluid.volume.FluidKey;
 import alexiil.mc.lib.attributes.fluid.volume.FluidKeys;
@@ -64,7 +65,10 @@ import net.minecraft.world.level.material.Material;
 import org.apache.logging.log4j.util.TriConsumer;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -247,9 +251,17 @@ public class HardcoreQuestingFabric implements ModInitializer, AbstractPlatform 
     }
     
     @Override
-    public FluidStack findFluidIn(ItemStack stack) {
-        FluidKey fluid = FluidItemUtil.getContainedFluid(stack);
-        return new FabricFluidStack(fluid.withAmount(fluid.entry.isEmpty() ? FluidAmount.ZERO : FluidAmount.ONE));
+    public List<FluidStack> findFluidsIn(ItemStack stack) {
+        GroupedFluidInvView inv = FluidAttributes.GROUPED_INV_VIEW.get(stack);
+        Set<FluidKey> fluidTypes = inv.getStoredFluids();
+        if (fluidTypes.isEmpty())
+            return Collections.emptyList();
+        else {
+            List<FluidStack> fluids = new ArrayList<>();
+            for (FluidKey fluid : fluidTypes)
+                fluids.add(new FabricFluidStack(fluid.withAmount(inv.getAmount_F(fluid))));
+            return fluids;
+        }
     }
     
     @Override

--- a/forge/src/main/java/hardcorequesting/forge/HardcoreQuestingForge.java
+++ b/forge/src/main/java/hardcorequesting/forge/HardcoreQuestingForge.java
@@ -67,6 +67,7 @@ import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.fluids.FluidAttributes;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
+import net.minecraftforge.fluids.capability.IFluidHandlerItem;
 import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
@@ -76,10 +77,14 @@ import net.minecraftforge.fmllegacy.server.ServerLifecycleHooks;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 import org.apache.logging.log4j.util.TriConsumer;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -345,10 +350,21 @@ public class HardcoreQuestingForge implements AbstractPlatform {
     }
     
     @Override
-    public FluidStack findFluidIn(ItemStack stack) {
-        return new ForgeFluidStack(stack.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY)
-                .map(handler -> handler.getFluidInTank(0))
-                .orElse(net.minecraftforge.fluids.FluidStack.EMPTY));
+    public List<FluidStack> findFluidsIn(ItemStack stack) {
+        return stack.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY)
+                .map(HardcoreQuestingForge::getAllFluidsIn)
+                .orElse(Collections.emptyList());
+    }
+    
+    @NotNull
+    private static List<FluidStack> getAllFluidsIn(IFluidHandlerItem handler) {
+        List<FluidStack> fluids = new ArrayList<>();
+        for (int tank = 0; tank < handler.getTanks(); tank++) {
+            net.minecraftforge.fluids.FluidStack fluid = handler.getFluidInTank(tank);
+            if (!fluid.isEmpty())
+                fluids.add(new ForgeFluidStack(fluid));
+        }
+        return fluids;
     }
     
     // Private class extending RenderType as a simple workaround to access protected fields.

--- a/forge/src/main/java/hardcorequesting/forge/HardcoreQuestingForge.java
+++ b/forge/src/main/java/hardcorequesting/forge/HardcoreQuestingForge.java
@@ -378,9 +378,9 @@ public class HardcoreQuestingForge implements AbstractPlatform {
         private static RenderType createFluid(ResourceLocation location) {
             return RenderType.create(
                     HardcoreQuestingCore.ID + ":fluid_type",
-                    DefaultVertexFormat.POSITION_TEX_COLOR, VertexFormat.Mode.QUADS, 256, true, false,
+                    DefaultVertexFormat.POSITION_COLOR_TEX, VertexFormat.Mode.QUADS, 256, true, false,
                     RenderType.CompositeState.builder()
-                            .setShaderState(RenderStateShard.RENDERTYPE_TRANSLUCENT_SHADER)
+                            .setShaderState(RenderStateShard.POSITION_COLOR_TEX_SHADER)
                             .setLightmapState(RenderStateShard.LIGHTMAP)
                             .setTextureState(new RenderStateShard.TextureStateShard(location, false, false))
                             .setTransparencyState(RenderStateShard.TRANSLUCENT_TRANSPARENCY)
@@ -404,10 +404,10 @@ public class HardcoreQuestingForge implements AbstractPlatform {
         MultiBufferSource.BufferSource source = Minecraft.getInstance().renderBuffers().bufferSource();
         VertexConsumer builder = blockMaterial.buffer(source, HardcoreQuestingForge.CustomRenderTypes::createFluid);
         Matrix4f matrix = matrices.last().pose();
-        builder.vertex(matrix, x2, y1, 0).uv(sprite.getU1(), sprite.getV0()).color(r, g, b, a).endVertex();
-        builder.vertex(matrix, x1, y1, 0).uv(sprite.getU0(), sprite.getV0()).color(r, g, b, a).endVertex();
-        builder.vertex(matrix, x1, y2, 0).uv(sprite.getU0(), sprite.getV1()).color(r, g, b, a).endVertex();
-        builder.vertex(matrix, x2, y2, 0).uv(sprite.getU1(), sprite.getV1()).color(r, g, b, a).endVertex();
+        builder.vertex(matrix, x2, y1, 0).color(r, g, b, a).uv(sprite.getU1(), sprite.getV0()).endVertex();
+        builder.vertex(matrix, x1, y1, 0).color(r, g, b, a).uv(sprite.getU0(), sprite.getV0()).endVertex();
+        builder.vertex(matrix, x1, y2, 0).color(r, g, b, a).uv(sprite.getU0(), sprite.getV1()).endVertex();
+        builder.vertex(matrix, x2, y2, 0).color(r, g, b, a).uv(sprite.getU1(), sprite.getV1()).endVertex();
         source.endBatch();
     }
     


### PR DESCRIPTION
Unlike previous pull requests that consisted of fixes, tweaks, restoration of old features, or code cleanup, this PR has some new features, which should warrant a minor version bump.
Changes include:
- Fluid support for detection tasks (inventory items are checked for fluids)
- Fluids can now be used as icons for quests and certain tasks
- Quest icons will now default to the first item/fluid set to a quest task/reward (Closes #500)
- If an item has multiple types of fluids or multiple fluid tanks, all those fluids will show up when picking an item/fluid
- Fix forge-side fluid rendering (issue that was introduced from #580)

If the 5.6.2 version proposal is accepted, #586 should be merged **before** this PR.