### PR TITLE
Fabric Gametest

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -30,4 +30,5 @@ jobs:
 #        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
 #        restore-keys: ${{ runner.os }}-gradle
     - name: Build with Gradle
+      timeout-minutes: 10
       run: ./gradlew build --stacktrace

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -112,8 +112,10 @@ loom {
     runs {
         gametest {
             server()
-            name = "Game Test"
-            vmArg "-Dfabric-api.gametest.server=true"
+            name "Game Test"
+            vmArg "-Dfabric-api.gametest"
+            vmArg "-Dfabric-api.gametest.report-file=${project.buildDir}/junit.xml"
+            runDir "build/gametest"
         }
     }
 }

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -107,3 +107,14 @@ sourcesJar {
 tasks.withType(JavaCompile) {
     options.encoding = "UTF-8"
 }
+
+loom {
+    runs {
+        gametest {
+            server()
+            name = "Game Test"
+            vmArg "-Dfabric-api.gametest.server=true"
+        }
+    }
+}
+test.dependsOn runGametest

--- a/fabric/gradle.properties
+++ b/fabric/gradle.properties
@@ -1,5 +1,5 @@
 
-fabric_version=0.40.0+1.17
+fabric_version=0.40.8+1.17
 
 architectury_version=2.5.28
 

--- a/fabric/gradle.properties
+++ b/fabric/gradle.properties
@@ -1,5 +1,5 @@
 
-fabric_version=0.39.1+1.17
+fabric_version=0.40.0+1.17
 
 architectury_version=2.5.28
 

--- a/fabric/src/main/java/hardcorequesting/fabric/HQMTest.java
+++ b/fabric/src/main/java/hardcorequesting/fabric/HQMTest.java
@@ -1,0 +1,17 @@
+package hardcorequesting.fabric;
+
+import hardcorequesting.common.quests.QuestLine;
+import net.fabricmc.fabric.api.gametest.v1.FabricGameTest;
+import net.minecraft.gametest.framework.GameTest;
+import net.minecraft.gametest.framework.GameTestHelper;
+
+public class HQMTest {
+    
+    @GameTest(template = FabricGameTest.EMPTY_STRUCTURE)
+    public void questLineExists(GameTestHelper helper) {
+        
+        if (QuestLine.getActiveQuestLine() == null)
+            helper.fail("Quest line has not been initialized.");
+        else helper.succeed();
+    }
+}

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -24,6 +24,9 @@
     "main": [
       "hardcorequesting.fabric.HardcoreQuestingFabric"
     ],
+    "fabric-gametest": [
+      "hardcorequesting.fabric.HQMTest"
+    ],
     "cardinal-components": [
       "hardcorequesting.fabric.capabilities.ModCapabilities"
     ]


### PR DESCRIPTION
Currently facing a problem where the game test crashes while loading mixins with a NullPointerException, indirectly caused by
`[main/WARN] (mixin) Error loading class: net/minecraft/world/level/storage/LevelStorage$Session (java.lang.ClassNotFoundException: net/minecraft/world/level/storage/LevelStorage$Session)`
when loading the mixin at https://github.com/FabricMC/fabric/blob/1.17/fabric-gametest-api-v1/src/main/java/net/fabricmc/fabric/mixin/gametest/server/MainMixin.java#L58
I understand it to be some mappings + mixin loader issue, but not enough to tell where to go from here.
