### PR TITLE
Book catalyst recipe and replace access transforms

### DIFF
--- a/common/src/main/java/hardcorequesting/common/client/sounds/Sounds.java
+++ b/common/src/main/java/hardcorequesting/common/client/sounds/Sounds.java
@@ -5,6 +5,8 @@ import hardcorequesting.common.HardcoreQuestingCore;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvent;
 
+import java.util.function.Supplier;
+
 public enum Sounds {
     COMPLETE("complete"),
     LIFE("heart"),
@@ -13,6 +15,7 @@ public enum Sounds {
     ROTTEN("rotten");
     
     private final ResourceLocation soundId;
+    private Supplier<SoundEvent> supplier;
     
     Sounds(String soundName) {
         this.soundId = new ResourceLocation(HardcoreQuestingCore.ID, soundName);
@@ -23,12 +26,12 @@ public enum Sounds {
     }
     
     public SoundEvent getSound() {
-        return HardcoreQuestingCore.platform.getSoundEvent(soundId);
+        return supplier.get();
     }
     
     public static void registerSounds() {
         for (Sounds sound : Sounds.values()) {
-            HardcoreQuestingCore.platform.registerSound(sound.soundId, () -> new SoundEvent(sound.soundId));
+            sound.supplier = HardcoreQuestingCore.platform.registerSound(sound.soundId, () -> new SoundEvent(sound.soundId));
         }
     }
 }

--- a/common/src/main/java/hardcorequesting/common/client/sounds/Sounds.java
+++ b/common/src/main/java/hardcorequesting/common/client/sounds/Sounds.java
@@ -31,7 +31,7 @@ public enum Sounds {
     
     public static void registerSounds() {
         for (Sounds sound : Sounds.values()) {
-            sound.supplier = HardcoreQuestingCore.platform.registerSound(sound.soundId, () -> new SoundEvent(sound.soundId));
+            sound.supplier = HardcoreQuestingCore.platform.registerSound(sound.soundId.getPath(), () -> new SoundEvent(sound.soundId));
         }
     }
 }

--- a/common/src/main/java/hardcorequesting/common/items/ModItems.java
+++ b/common/src/main/java/hardcorequesting/common/items/ModItems.java
@@ -1,7 +1,6 @@
 package hardcorequesting.common.items;
 
 
-import hardcorequesting.common.HardcoreQuestingCore;
 import hardcorequesting.common.bag.BagTier;
 import hardcorequesting.common.util.RegisterHelper;
 
@@ -24,16 +23,8 @@ public class ModItems {
     public static Supplier<ItemHeart> rottenHeart;
     
     public static void init() {
-        book = RegisterHelper.registerItem("quest_book", () -> {
-            QuestBookItem item = new QuestBookItem(false);
-            HardcoreQuestingCore.platform.setCraftingRemainingItem(item, item);
-            return item;
-        });
-        enabledBook = RegisterHelper.registerItem("enabled_quest_book", () -> {
-            QuestBookItem item = new QuestBookItem(true);
-            HardcoreQuestingCore.platform.setCraftingRemainingItem(item, item);
-            return item;
-        });
+        book = RegisterHelper.registerItem("quest_book", () -> new QuestBookItem(false));
+        enabledBook = RegisterHelper.registerItem("enabled_quest_book", () -> new QuestBookItem(true));
         basicBag = RegisterHelper.registerItem("basic_bag", () -> new BagItem(BagTier.BASIC));
         goodBag = RegisterHelper.registerItem("good_bag", () -> new BagItem(BagTier.GOOD));
         greaterBag = RegisterHelper.registerItem("greater_bag", () -> new BagItem(BagTier.GREATER));

--- a/common/src/main/java/hardcorequesting/common/items/crafting/BookCatalystRecipe.java
+++ b/common/src/main/java/hardcorequesting/common/items/crafting/BookCatalystRecipe.java
@@ -22,7 +22,7 @@ public class BookCatalystRecipe extends ShapedRecipe {
         for (int i = 0; i < remaining.size(); i++) {
             ItemStack stack = container.getItem(i);
             if (stack.is(ModItems.book.get()) || stack.is(ModItems.enabledBook.get())) {
-                remaining.set(i, stack);
+                remaining.set(i, stack.copy());
             }
         }
         return remaining;

--- a/common/src/main/java/hardcorequesting/common/items/crafting/BookCatalystRecipe.java
+++ b/common/src/main/java/hardcorequesting/common/items/crafting/BookCatalystRecipe.java
@@ -1,0 +1,35 @@
+package hardcorequesting.common.items.crafting;
+
+import hardcorequesting.common.items.ModItems;
+import net.minecraft.core.NonNullList;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.inventory.CraftingContainer;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.crafting.RecipeSerializer;
+import net.minecraft.world.item.crafting.ShapedRecipe;
+
+public class BookCatalystRecipe extends ShapedRecipe {
+    
+    public BookCatalystRecipe(ResourceLocation id, String group, int width, int height, NonNullList<Ingredient> ingredients, ItemStack result) {
+        super(id, group, width, height, ingredients, result);
+    }
+    
+    @Override
+    public NonNullList<ItemStack> getRemainingItems(CraftingContainer container) {
+        NonNullList<ItemStack> remaining = super.getRemainingItems(container);
+        
+        for (int i = 0; i < remaining.size(); i++) {
+            ItemStack stack = container.getItem(i);
+            if (stack.is(ModItems.book.get()) || stack.is(ModItems.enabledBook.get())) {
+                remaining.set(i, stack);
+            }
+        }
+        return remaining;
+    }
+    
+    @Override
+    public RecipeSerializer<?> getSerializer() {
+        return ModRecipes.bookCatalystSerializer.get();
+    }
+}

--- a/common/src/main/java/hardcorequesting/common/items/crafting/ModRecipes.java
+++ b/common/src/main/java/hardcorequesting/common/items/crafting/ModRecipes.java
@@ -1,0 +1,14 @@
+package hardcorequesting.common.items.crafting;
+
+import hardcorequesting.common.HardcoreQuestingCore;
+import net.minecraft.world.item.crafting.RecipeSerializer;
+
+import java.util.function.Supplier;
+
+public class ModRecipes {
+    public static Supplier<RecipeSerializer<?>> bookCatalystSerializer;
+    
+    public static void init() {
+        bookCatalystSerializer = HardcoreQuestingCore.platform.registerBookRecipeSerializer("book_catalyst_shaped");
+    }
+}

--- a/common/src/main/java/hardcorequesting/common/platform/AbstractPlatform.java
+++ b/common/src/main/java/hardcorequesting/common/platform/AbstractPlatform.java
@@ -132,11 +132,11 @@ public interface AbstractPlatform {
     
     Fraction getBucketAmount();
     
-    <T extends Block> Supplier<T> registerBlock(ResourceLocation location, Supplier<T> block);
+    <T extends Block> Supplier<T> registerBlock(String id, Supplier<T> block);
     
-    Supplier<SoundEvent> registerSound(ResourceLocation location, Supplier<SoundEvent> sound);
+    Supplier<SoundEvent> registerSound(String id, Supplier<SoundEvent> sound);
     
-    <T extends Item> Supplier<T> registerItem(ResourceLocation location, Supplier<T> item);
+    <T extends Item> Supplier<T> registerItem(String id, Supplier<T> item);
     
-    <T extends BlockEntity> Supplier<BlockEntityType<T>> registerBlockEntity(ResourceLocation location, BiFunction<BlockPos, BlockState, T> constructor);
+    <T extends BlockEntity> Supplier<BlockEntityType<T>> registerBlockEntity(String id, BiFunction<BlockPos, BlockState, T> constructor);
 }

--- a/common/src/main/java/hardcorequesting/common/platform/AbstractPlatform.java
+++ b/common/src/main/java/hardcorequesting/common/platform/AbstractPlatform.java
@@ -116,8 +116,6 @@ public interface AbstractPlatform {
     
     AbstractBarrelBlockEntity createBarrelBlockEntity(BlockPos pos, BlockState state);
     
-    void setCraftingRemainingItem(Item item, Item craftingRemainingItem);
-    
     FluidStack createEmptyFluidStack();
     
     FluidStack createFluidStack(Fluid fluid, Fraction amount);

--- a/common/src/main/java/hardcorequesting/common/platform/AbstractPlatform.java
+++ b/common/src/main/java/hardcorequesting/common/platform/AbstractPlatform.java
@@ -132,19 +132,11 @@ public interface AbstractPlatform {
     
     Fraction getBucketAmount();
     
-    Block getBlock(ResourceLocation location);
+    Supplier<Block> registerBlock(ResourceLocation location, Supplier<Block> block);
     
-    SoundEvent getSoundEvent(ResourceLocation location);
+    Supplier<SoundEvent> registerSound(ResourceLocation location, Supplier<SoundEvent> sound);
     
-    Item getItem(ResourceLocation location);
+    Supplier<Item> registerItem(ResourceLocation location, Supplier<Item> item);
     
-    BlockEntityType<?> getBlockEntity(ResourceLocation location);
-    
-    void registerBlock(ResourceLocation location, Supplier<Block> block);
-    
-    void registerSound(ResourceLocation location, Supplier<SoundEvent> sound);
-    
-    void registerItem(ResourceLocation location, Supplier<Item> item);
-    
-    void registerBlockEntity(ResourceLocation location, BiFunction<BlockPos, BlockState, ? extends BlockEntity> constructor);
+    Supplier<BlockEntityType<?>> registerBlockEntity(ResourceLocation location, BiFunction<BlockPos, BlockState, ? extends BlockEntity> constructor);
 }

--- a/common/src/main/java/hardcorequesting/common/platform/AbstractPlatform.java
+++ b/common/src/main/java/hardcorequesting/common/platform/AbstractPlatform.java
@@ -132,11 +132,11 @@ public interface AbstractPlatform {
     
     Fraction getBucketAmount();
     
-    Supplier<Block> registerBlock(ResourceLocation location, Supplier<Block> block);
+    <T extends Block> Supplier<T> registerBlock(ResourceLocation location, Supplier<T> block);
     
     Supplier<SoundEvent> registerSound(ResourceLocation location, Supplier<SoundEvent> sound);
     
-    Supplier<Item> registerItem(ResourceLocation location, Supplier<Item> item);
+    <T extends Item> Supplier<T> registerItem(ResourceLocation location, Supplier<T> item);
     
-    Supplier<BlockEntityType<?>> registerBlockEntity(ResourceLocation location, BiFunction<BlockPos, BlockState, ? extends BlockEntity> constructor);
+    <T extends BlockEntity> Supplier<BlockEntityType<T>> registerBlockEntity(ResourceLocation location, BiFunction<BlockPos, BlockState, T> constructor);
 }

--- a/common/src/main/java/hardcorequesting/common/platform/AbstractPlatform.java
+++ b/common/src/main/java/hardcorequesting/common/platform/AbstractPlatform.java
@@ -26,6 +26,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.Block;
@@ -139,4 +140,7 @@ public interface AbstractPlatform {
     <T extends Item> Supplier<T> registerItem(String id, Supplier<T> item);
     
     <T extends BlockEntity> Supplier<BlockEntityType<T>> registerBlockEntity(String id, BiFunction<BlockPos, BlockState, T> constructor);
+    
+    Supplier<RecipeSerializer<?>> registerBookRecipeSerializer(String id);
+    
 }

--- a/common/src/main/java/hardcorequesting/common/util/RegisterHelper.java
+++ b/common/src/main/java/hardcorequesting/common/util/RegisterHelper.java
@@ -17,30 +17,15 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class RegisterHelper {
-    public static Supplier<Block> delegateBlock(String id) {
-        ResourceLocation location = new ResourceLocation(HardcoreQuestingCore.ID, id);
-        return () -> HardcoreQuestingCore.platform.getBlock(location);
-    }
-    
-    public static Supplier<Item> delegateItem(String id) {
-        ResourceLocation location = new ResourceLocation(HardcoreQuestingCore.ID, id);
-        return () -> HardcoreQuestingCore.platform.getItem(location);
-    }
-    
-    public static Supplier<BlockEntityType<?>> delegateBlockEntity(String id) {
-        ResourceLocation location = new ResourceLocation(HardcoreQuestingCore.ID, id);
-        return () -> HardcoreQuestingCore.platform.getBlockEntity(location);
-    }
     
     public static <T extends Block> Supplier<T> registerBlock(String id, Supplier<T> block, Function<T, BlockItem> itemFunction) {
-        HardcoreQuestingCore.platform.registerBlock(new ResourceLocation(HardcoreQuestingCore.ID, id), (Supplier<Block>) block);
-        registerItem(id, () -> itemFunction.apply((T) delegateBlock(id).get()));
-        return (Supplier<T>) delegateBlock(id);
+        Supplier<Block> supplier = HardcoreQuestingCore.platform.registerBlock(new ResourceLocation(HardcoreQuestingCore.ID, id), (Supplier<Block>) block);
+        registerItem(id, () -> itemFunction.apply((T) supplier.get()));
+        return (Supplier<T>) supplier;
     }
     
     public static <T extends Item> Supplier<T> registerItem(String id, Supplier<T> item) {
-        HardcoreQuestingCore.platform.registerItem(new ResourceLocation(HardcoreQuestingCore.ID, id), (Supplier<Item>) item);
-        return (Supplier<T>) delegateItem(id);
+        return (Supplier<T>) HardcoreQuestingCore.platform.registerItem(new ResourceLocation(HardcoreQuestingCore.ID, id), (Supplier<Item>) item);
     }
     
     public static void register() {
@@ -50,7 +35,6 @@ public class RegisterHelper {
     }
     
     public static <T extends BlockEntity> Supplier<BlockEntityType<T>> registerTileEntity(String id, BiFunction<BlockPos, BlockState, T> blockEntitySupplier) {
-        HardcoreQuestingCore.platform.registerBlockEntity(new ResourceLocation(HardcoreQuestingCore.ID, id), blockEntitySupplier);
-        return (Supplier) delegateBlockEntity(id);
+        return (Supplier) HardcoreQuestingCore.platform.registerBlockEntity(new ResourceLocation(HardcoreQuestingCore.ID, id), blockEntitySupplier);
     }
 }

--- a/common/src/main/java/hardcorequesting/common/util/RegisterHelper.java
+++ b/common/src/main/java/hardcorequesting/common/util/RegisterHelper.java
@@ -4,7 +4,6 @@ import hardcorequesting.common.HardcoreQuestingCore;
 import hardcorequesting.common.blocks.ModBlocks;
 import hardcorequesting.common.items.ModItems;
 import net.minecraft.core.BlockPos;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.Block;
@@ -19,13 +18,13 @@ import java.util.function.Supplier;
 public class RegisterHelper {
     
     public static <T extends Block> Supplier<T> registerBlock(String id, Supplier<T> block, Function<T, BlockItem> itemFunction) {
-        Supplier<T> supplier = HardcoreQuestingCore.platform.registerBlock(new ResourceLocation(HardcoreQuestingCore.ID, id), block);
+        Supplier<T> supplier = HardcoreQuestingCore.platform.registerBlock(id, block);
         registerItem(id, () -> itemFunction.apply(supplier.get()));
         return supplier;
     }
     
     public static <T extends Item> Supplier<T> registerItem(String id, Supplier<T> item) {
-        return HardcoreQuestingCore.platform.registerItem(new ResourceLocation(HardcoreQuestingCore.ID, id), item);
+        return HardcoreQuestingCore.platform.registerItem(id, item);
     }
     
     public static void register() {
@@ -35,6 +34,6 @@ public class RegisterHelper {
     }
     
     public static <T extends BlockEntity> Supplier<BlockEntityType<T>> registerTileEntity(String id, BiFunction<BlockPos, BlockState, T> blockEntitySupplier) {
-        return HardcoreQuestingCore.platform.registerBlockEntity(new ResourceLocation(HardcoreQuestingCore.ID, id), blockEntitySupplier);
+        return HardcoreQuestingCore.platform.registerBlockEntity(id, blockEntitySupplier);
     }
 }

--- a/common/src/main/java/hardcorequesting/common/util/RegisterHelper.java
+++ b/common/src/main/java/hardcorequesting/common/util/RegisterHelper.java
@@ -19,13 +19,13 @@ import java.util.function.Supplier;
 public class RegisterHelper {
     
     public static <T extends Block> Supplier<T> registerBlock(String id, Supplier<T> block, Function<T, BlockItem> itemFunction) {
-        Supplier<Block> supplier = HardcoreQuestingCore.platform.registerBlock(new ResourceLocation(HardcoreQuestingCore.ID, id), (Supplier<Block>) block);
-        registerItem(id, () -> itemFunction.apply((T) supplier.get()));
-        return (Supplier<T>) supplier;
+        Supplier<T> supplier = HardcoreQuestingCore.platform.registerBlock(new ResourceLocation(HardcoreQuestingCore.ID, id), block);
+        registerItem(id, () -> itemFunction.apply(supplier.get()));
+        return supplier;
     }
     
     public static <T extends Item> Supplier<T> registerItem(String id, Supplier<T> item) {
-        return (Supplier<T>) HardcoreQuestingCore.platform.registerItem(new ResourceLocation(HardcoreQuestingCore.ID, id), (Supplier<Item>) item);
+        return HardcoreQuestingCore.platform.registerItem(new ResourceLocation(HardcoreQuestingCore.ID, id), item);
     }
     
     public static void register() {
@@ -35,6 +35,6 @@ public class RegisterHelper {
     }
     
     public static <T extends BlockEntity> Supplier<BlockEntityType<T>> registerTileEntity(String id, BiFunction<BlockPos, BlockState, T> blockEntitySupplier) {
-        return (Supplier) HardcoreQuestingCore.platform.registerBlockEntity(new ResourceLocation(HardcoreQuestingCore.ID, id), blockEntitySupplier);
+        return HardcoreQuestingCore.platform.registerBlockEntity(new ResourceLocation(HardcoreQuestingCore.ID, id), blockEntitySupplier);
     }
 }

--- a/common/src/main/java/hardcorequesting/common/util/RegisterHelper.java
+++ b/common/src/main/java/hardcorequesting/common/util/RegisterHelper.java
@@ -3,6 +3,7 @@ package hardcorequesting.common.util;
 import hardcorequesting.common.HardcoreQuestingCore;
 import hardcorequesting.common.blocks.ModBlocks;
 import hardcorequesting.common.items.ModItems;
+import hardcorequesting.common.items.crafting.ModRecipes;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
@@ -31,6 +32,7 @@ public class RegisterHelper {
         ModBlocks.init();
         ModBlocks.registerTileEntities();
         ModItems.init();
+        ModRecipes.init();
     }
     
     public static <T extends BlockEntity> Supplier<BlockEntityType<T>> registerTileEntity(String id, BiFunction<BlockPos, BlockState, T> blockEntitySupplier) {

--- a/common/src/main/resources/data/hardcorequesting/recipes/barrel.json
+++ b/common/src/main/resources/data/hardcorequesting/recipes/barrel.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shaped",
+  "type": "hardcorequesting:book_catalyst_shaped",
   "pattern": [
     "wgw",
     "gqg",

--- a/common/src/main/resources/data/hardcorequesting/recipes/barrel_2.json
+++ b/common/src/main/resources/data/hardcorequesting/recipes/barrel_2.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shaped",
+  "type": "hardcorequesting:book_catalyst_shaped",
   "pattern": [
     "wgw",
     "gqg",

--- a/fabric/src/main/java/hardcorequesting/fabric/BookCatalystRecipeSerializer.java
+++ b/fabric/src/main/java/hardcorequesting/fabric/BookCatalystRecipeSerializer.java
@@ -1,0 +1,32 @@
+package hardcorequesting.fabric;
+
+import com.google.gson.JsonObject;
+import hardcorequesting.common.items.crafting.BookCatalystRecipe;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.crafting.RecipeSerializer;
+import net.minecraft.world.item.crafting.ShapedRecipe;
+
+/**
+ * Same as the corresponding class in the forge module, but does not extend ForgeRegistryEntry
+ */
+public class BookCatalystRecipeSerializer implements RecipeSerializer<BookCatalystRecipe> {
+    @Override
+    public BookCatalystRecipe fromJson(ResourceLocation recipeId, JsonObject json) {
+        ShapedRecipe recipe = RecipeSerializer.SHAPED_RECIPE.fromJson(recipeId, json);
+    
+        return new BookCatalystRecipe(recipe.getId(), recipe.getGroup(), recipe.getWidth(), recipe.getHeight(), recipe.getIngredients(), recipe.getResultItem());
+    }
+    
+    @Override
+    public BookCatalystRecipe fromNetwork(ResourceLocation recipeId, FriendlyByteBuf buffer) {
+        ShapedRecipe recipe = RecipeSerializer.SHAPED_RECIPE.fromNetwork(recipeId, buffer);
+    
+        return new BookCatalystRecipe(recipe.getId(), recipe.getGroup(), recipe.getWidth(), recipe.getHeight(), recipe.getIngredients(), recipe.getResultItem());
+    }
+    
+    @Override
+    public void toNetwork(FriendlyByteBuf buffer, BookCatalystRecipe recipe) {
+        RecipeSerializer.SHAPED_RECIPE.toNetwork(buffer, recipe);
+    }
+}

--- a/fabric/src/main/java/hardcorequesting/fabric/HardcoreQuestingFabric.java
+++ b/fabric/src/main/java/hardcorequesting/fabric/HardcoreQuestingFabric.java
@@ -271,46 +271,30 @@ public class HardcoreQuestingFabric implements ModInitializer, AbstractPlatform 
     
     @Override
     public Fraction getBucketAmount() {
-        return Fraction.ofWhole(1);
+        return Fraction.of(FluidAmount.BUCKET.whole, FluidAmount.BUCKET.numerator, FluidAmount.BUCKET.denominator);
     }
     
     @Override
-    public Block getBlock(ResourceLocation location) {
-        return Registry.BLOCK.get(location);
-    }
-    
-    @Override
-    public SoundEvent getSoundEvent(ResourceLocation location) {
-        return Registry.SOUND_EVENT.get(location);
-    }
-    
-    @Override
-    public Item getItem(ResourceLocation location) {
-        return Registry.ITEM.get(location);
-    }
-    
-    @Override
-    public BlockEntityType<?> getBlockEntity(ResourceLocation location) {
-        return Registry.BLOCK_ENTITY_TYPE.get(location);
-    }
-    
-    @Override
-    public void registerBlock(ResourceLocation location, Supplier<Block> block) {
+    public Supplier<Block> registerBlock(ResourceLocation location, Supplier<Block> block) {
         Registry.register(Registry.BLOCK, location, block.get());
+        return () -> Registry.BLOCK.get(location);
     }
     
     @Override
-    public void registerSound(ResourceLocation location, Supplier<SoundEvent> sound) {
+    public Supplier<SoundEvent> registerSound(ResourceLocation location, Supplier<SoundEvent> sound) {
         Registry.register(Registry.SOUND_EVENT, location, sound.get());
+        return () -> Registry.SOUND_EVENT.get(location);
     }
     
     @Override
-    public void registerItem(ResourceLocation location, Supplier<Item> item) {
+    public Supplier<Item> registerItem(ResourceLocation location, Supplier<Item> item) {
         Registry.register(Registry.ITEM, location, item.get());
+        return () -> Registry.ITEM.get(location);
     }
     
     @Override
-    public void registerBlockEntity(ResourceLocation location, BiFunction<BlockPos, BlockState, ? extends BlockEntity> constructor) {
+    public Supplier<BlockEntityType<?>> registerBlockEntity(ResourceLocation location, BiFunction<BlockPos, BlockState, ? extends BlockEntity> constructor) {
         Registry.register(Registry.BLOCK_ENTITY_TYPE, location, FabricBlockEntityTypeBuilder.create(constructor::apply).build(null));
+        return () -> Registry.BLOCK_ENTITY_TYPE.get(location);
     }
 }

--- a/fabric/src/main/java/hardcorequesting/fabric/HardcoreQuestingFabric.java
+++ b/fabric/src/main/java/hardcorequesting/fabric/HardcoreQuestingFabric.java
@@ -237,11 +237,6 @@ public class HardcoreQuestingFabric implements ModInitializer, AbstractPlatform 
     }
     
     @Override
-    public void setCraftingRemainingItem(Item item, Item craftingRemainingItem) {
-        item.craftingRemainingItem = craftingRemainingItem;
-    }
-    
-    @Override
     public FluidStack createEmptyFluidStack() {
         return new FabricFluidStack(FluidVolumeUtil.EMPTY);
     }

--- a/fabric/src/main/java/hardcorequesting/fabric/HardcoreQuestingFabric.java
+++ b/fabric/src/main/java/hardcorequesting/fabric/HardcoreQuestingFabric.java
@@ -274,10 +274,11 @@ public class HardcoreQuestingFabric implements ModInitializer, AbstractPlatform 
         return Fraction.of(FluidAmount.BUCKET.whole, FluidAmount.BUCKET.numerator, FluidAmount.BUCKET.denominator);
     }
     
+    @SuppressWarnings("unchecked")
     @Override
-    public Supplier<Block> registerBlock(ResourceLocation location, Supplier<Block> block) {
+    public <T extends Block> Supplier<T> registerBlock(ResourceLocation location, Supplier<T> block) {
         Registry.register(Registry.BLOCK, location, block.get());
-        return () -> Registry.BLOCK.get(location);
+        return () -> (T) Registry.BLOCK.get(location);
     }
     
     @Override
@@ -286,15 +287,17 @@ public class HardcoreQuestingFabric implements ModInitializer, AbstractPlatform 
         return () -> Registry.SOUND_EVENT.get(location);
     }
     
+    @SuppressWarnings("unchecked")
     @Override
-    public Supplier<Item> registerItem(ResourceLocation location, Supplier<Item> item) {
+    public <T extends Item> Supplier<T> registerItem(ResourceLocation location, Supplier<T> item) {
         Registry.register(Registry.ITEM, location, item.get());
-        return () -> Registry.ITEM.get(location);
+        return () -> (T) Registry.ITEM.get(location);
     }
     
+    @SuppressWarnings("unchecked")
     @Override
-    public Supplier<BlockEntityType<?>> registerBlockEntity(ResourceLocation location, BiFunction<BlockPos, BlockState, ? extends BlockEntity> constructor) {
+    public <T extends BlockEntity> Supplier<BlockEntityType<T>> registerBlockEntity(ResourceLocation location, BiFunction<BlockPos, BlockState, T> constructor) {
         Registry.register(Registry.BLOCK_ENTITY_TYPE, location, FabricBlockEntityTypeBuilder.create(constructor::apply).build(null));
-        return () -> Registry.BLOCK_ENTITY_TYPE.get(location);
+        return () -> (BlockEntityType<T>) Registry.BLOCK_ENTITY_TYPE.get(location);
     }
 }

--- a/fabric/src/main/java/hardcorequesting/fabric/HardcoreQuestingFabric.java
+++ b/fabric/src/main/java/hardcorequesting/fabric/HardcoreQuestingFabric.java
@@ -276,27 +276,31 @@ public class HardcoreQuestingFabric implements ModInitializer, AbstractPlatform 
     
     @SuppressWarnings("unchecked")
     @Override
-    public <T extends Block> Supplier<T> registerBlock(ResourceLocation location, Supplier<T> block) {
+    public <T extends Block> Supplier<T> registerBlock(String id, Supplier<T> block) {
+        ResourceLocation location = new ResourceLocation(HardcoreQuestingCore.ID, id);
         Registry.register(Registry.BLOCK, location, block.get());
         return () -> (T) Registry.BLOCK.get(location);
     }
     
     @Override
-    public Supplier<SoundEvent> registerSound(ResourceLocation location, Supplier<SoundEvent> sound) {
+    public Supplier<SoundEvent> registerSound(String id, Supplier<SoundEvent> sound) {
+        ResourceLocation location = new ResourceLocation(HardcoreQuestingCore.ID, id);
         Registry.register(Registry.SOUND_EVENT, location, sound.get());
         return () -> Registry.SOUND_EVENT.get(location);
     }
     
     @SuppressWarnings("unchecked")
     @Override
-    public <T extends Item> Supplier<T> registerItem(ResourceLocation location, Supplier<T> item) {
+    public <T extends Item> Supplier<T> registerItem(String id, Supplier<T> item) {
+        ResourceLocation location = new ResourceLocation(HardcoreQuestingCore.ID, id);
         Registry.register(Registry.ITEM, location, item.get());
         return () -> (T) Registry.ITEM.get(location);
     }
     
     @SuppressWarnings("unchecked")
     @Override
-    public <T extends BlockEntity> Supplier<BlockEntityType<T>> registerBlockEntity(ResourceLocation location, BiFunction<BlockPos, BlockState, T> constructor) {
+    public <T extends BlockEntity> Supplier<BlockEntityType<T>> registerBlockEntity(String id, BiFunction<BlockPos, BlockState, T> constructor) {
+        ResourceLocation location = new ResourceLocation(HardcoreQuestingCore.ID, id);
         Registry.register(Registry.BLOCK_ENTITY_TYPE, location, FabricBlockEntityTypeBuilder.create(constructor::apply).build(null));
         return () -> (BlockEntityType<T>) Registry.BLOCK_ENTITY_TYPE.get(location);
     }

--- a/fabric/src/main/java/hardcorequesting/fabric/HardcoreQuestingFabric.java
+++ b/fabric/src/main/java/hardcorequesting/fabric/HardcoreQuestingFabric.java
@@ -54,6 +54,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -303,5 +304,12 @@ public class HardcoreQuestingFabric implements ModInitializer, AbstractPlatform 
         ResourceLocation location = new ResourceLocation(HardcoreQuestingCore.ID, id);
         Registry.register(Registry.BLOCK_ENTITY_TYPE, location, FabricBlockEntityTypeBuilder.create(constructor::apply).build(null));
         return () -> (BlockEntityType<T>) Registry.BLOCK_ENTITY_TYPE.get(location);
+    }
+    
+    @Override
+    public Supplier<RecipeSerializer<?>> registerBookRecipeSerializer(String id) {
+        ResourceLocation location = new ResourceLocation(HardcoreQuestingCore.ID, id);
+        Registry.register(Registry.RECIPE_SERIALIZER, location, new BookCatalystRecipeSerializer());
+        return () -> Registry.RECIPE_SERIALIZER.get(location);
     }
 }

--- a/fabric/src/main/resources/hqm.accesswidener
+++ b/fabric/src/main/resources/hqm.accesswidener
@@ -1,6 +1,4 @@
 accessWidener   v1  named
-accessible field net/minecraft/world/item/Item craftingRemainingItem Lnet/minecraft/world/item/Item;
-mutable field net/minecraft/world/item/Item craftingRemainingItem Lnet/minecraft/world/item/Item;
 accessible field net/minecraft/client/renderer/RenderStateShard DEFAULT_ALPHA Lnet/minecraft/client/renderer/RenderStateShard$AlphaStateShard;
 accessible field net/minecraft/client/renderer/RenderStateShard TRANSLUCENT_TRANSPARENCY Lnet/minecraft/client/renderer/RenderStateShard$TransparencyStateShard;
 accessible field net/minecraft/client/renderer/RenderStateShard LIGHTMAP Lnet/minecraft/client/renderer/RenderStateShard$LightmapStateShard;

--- a/fabric/src/main/resources/hqm.accesswidener
+++ b/fabric/src/main/resources/hqm.accesswidener
@@ -1,4 +1,1 @@
 accessWidener   v1  named
-accessible field net/minecraft/client/renderer/RenderStateShard DEFAULT_ALPHA Lnet/minecraft/client/renderer/RenderStateShard$AlphaStateShard;
-accessible field net/minecraft/client/renderer/RenderStateShard TRANSLUCENT_TRANSPARENCY Lnet/minecraft/client/renderer/RenderStateShard$TransparencyStateShard;
-accessible field net/minecraft/client/renderer/RenderStateShard LIGHTMAP Lnet/minecraft/client/renderer/RenderStateShard$LightmapStateShard;

--- a/forge/src/main/java/hardcorequesting/forge/BookCatalystRecipeSerializer.java
+++ b/forge/src/main/java/hardcorequesting/forge/BookCatalystRecipeSerializer.java
@@ -1,0 +1,33 @@
+package hardcorequesting.forge;
+
+import com.google.gson.JsonObject;
+import hardcorequesting.common.items.crafting.BookCatalystRecipe;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.crafting.RecipeSerializer;
+import net.minecraft.world.item.crafting.ShapedRecipe;
+import net.minecraftforge.registries.ForgeRegistryEntry;
+
+/**
+ * Same as the corresponding class in the fabric module, but extends ForgeRegistryEntry
+ */
+public class BookCatalystRecipeSerializer extends ForgeRegistryEntry<RecipeSerializer<?>> implements RecipeSerializer<BookCatalystRecipe> {
+    @Override
+    public BookCatalystRecipe fromJson(ResourceLocation recipeId, JsonObject json) {
+        ShapedRecipe recipe = RecipeSerializer.SHAPED_RECIPE.fromJson(recipeId, json);
+    
+        return new BookCatalystRecipe(recipe.getId(), recipe.getGroup(), recipe.getWidth(), recipe.getHeight(), recipe.getIngredients(), recipe.getResultItem());
+    }
+    
+    @Override
+    public BookCatalystRecipe fromNetwork(ResourceLocation recipeId, FriendlyByteBuf buffer) {
+        ShapedRecipe recipe = RecipeSerializer.SHAPED_RECIPE.fromNetwork(recipeId, buffer);
+    
+        return new BookCatalystRecipe(recipe.getId(), recipe.getGroup(), recipe.getWidth(), recipe.getHeight(), recipe.getIngredients(), recipe.getResultItem());
+    }
+    
+    @Override
+    public void toNetwork(FriendlyByteBuf buffer, BookCatalystRecipe recipe) {
+        RecipeSerializer.SHAPED_RECIPE.toNetwork(buffer, recipe);
+    }
+}

--- a/forge/src/main/java/hardcorequesting/forge/HardcoreQuestingForge.java
+++ b/forge/src/main/java/hardcorequesting/forge/HardcoreQuestingForge.java
@@ -40,6 +40,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.level.GameRules;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
@@ -96,6 +97,7 @@ public class HardcoreQuestingForge implements AbstractPlatform {
     private final DeferredRegister<SoundEvent> sounds = DeferredRegister.create(ForgeRegistries.SOUND_EVENTS, HardcoreQuestingCore.ID);
     private final DeferredRegister<Block> block = DeferredRegister.create(ForgeRegistries.BLOCKS, HardcoreQuestingCore.ID);
     private final DeferredRegister<Item> item = DeferredRegister.create(ForgeRegistries.ITEMS, HardcoreQuestingCore.ID);
+    private final DeferredRegister<RecipeSerializer<?>> recipe = DeferredRegister.create(ForgeRegistries.RECIPE_SERIALIZERS, HardcoreQuestingCore.ID);
     private final DeferredRegister<BlockEntityType<?>> tileEntityType = DeferredRegister.create(ForgeRegistries.BLOCK_ENTITIES, HardcoreQuestingCore.ID);
     
     public HardcoreQuestingForge() {
@@ -105,6 +107,7 @@ public class HardcoreQuestingForge implements AbstractPlatform {
         sounds.register(FMLJavaModLoadingContext.get().getModEventBus());
         block.register(FMLJavaModLoadingContext.get().getModEventBus());
         item.register(FMLJavaModLoadingContext.get().getModEventBus());
+        recipe.register(FMLJavaModLoadingContext.get().getModEventBus());
         tileEntityType.register(FMLJavaModLoadingContext.get().getModEventBus());
         MinecraftForge.EVENT_BUS.<LivingDropsEvent>addListener(event -> {
             if (event.getEntityLiving() instanceof Player) {
@@ -434,5 +437,10 @@ public class HardcoreQuestingForge implements AbstractPlatform {
     @Override
     public <T extends BlockEntity> Supplier<BlockEntityType<T>> registerBlockEntity(String id, BiFunction<BlockPos, BlockState, T> constructor) {
         return tileEntityType.register(id, () -> BlockEntityType.Builder.of(constructor::apply).build(null));
+    }
+    
+    @Override
+    public Supplier<RecipeSerializer<?>> registerBookRecipeSerializer(String id) {
+        return recipe.register(id, BookCatalystRecipeSerializer::new);
     }
 }

--- a/forge/src/main/java/hardcorequesting/forge/HardcoreQuestingForge.java
+++ b/forge/src/main/java/hardcorequesting/forge/HardcoreQuestingForge.java
@@ -417,42 +417,22 @@ public class HardcoreQuestingForge implements AbstractPlatform {
     }
     
     @Override
-    public Block getBlock(ResourceLocation resourceLocation) {
-        return ForgeRegistries.BLOCKS.getValue(resourceLocation);
+    public Supplier<Block> registerBlock(ResourceLocation resourceLocation, Supplier<Block> supplier) {
+        return block.register(resourceLocation.getPath(), supplier);
     }
     
     @Override
-    public SoundEvent getSoundEvent(ResourceLocation location) {
-        return ForgeRegistries.SOUND_EVENTS.getValue(location);
+    public Supplier<SoundEvent> registerSound(ResourceLocation resourceLocation, Supplier<SoundEvent> supplier) {
+        return sounds.register(resourceLocation.getPath(), supplier);
     }
     
     @Override
-    public Item getItem(ResourceLocation resourceLocation) {
-        return ForgeRegistries.ITEMS.getValue(resourceLocation);
+    public Supplier<Item> registerItem(ResourceLocation resourceLocation, Supplier<Item> supplier) {
+        return item.register(resourceLocation.getPath(), supplier);
     }
     
     @Override
-    public BlockEntityType<?> getBlockEntity(ResourceLocation resourceLocation) {
-        return ForgeRegistries.BLOCK_ENTITIES.getValue(resourceLocation);
-    }
-    
-    @Override
-    public void registerBlock(ResourceLocation resourceLocation, Supplier<Block> supplier) {
-        block.register(resourceLocation.getPath(), supplier);
-    }
-    
-    @Override
-    public void registerSound(ResourceLocation resourceLocation, Supplier<SoundEvent> supplier) {
-        sounds.register(resourceLocation.getPath(), supplier);
-    }
-    
-    @Override
-    public void registerItem(ResourceLocation resourceLocation, Supplier<Item> supplier) {
-        item.register(resourceLocation.getPath(), supplier);
-    }
-    
-    @Override
-    public void registerBlockEntity(ResourceLocation resourceLocation, BiFunction<BlockPos, BlockState, ? extends BlockEntity> constructor) {
-        tileEntityType.register(resourceLocation.getPath(), () -> BlockEntityType.Builder.of(constructor::apply).build(null));
+    public Supplier<BlockEntityType<?>> registerBlockEntity(ResourceLocation resourceLocation, BiFunction<BlockPos, BlockState, ? extends BlockEntity> constructor) {
+        return tileEntityType.register(resourceLocation.getPath(), () -> BlockEntityType.Builder.of(constructor::apply).build(null));
     }
 }

--- a/forge/src/main/java/hardcorequesting/forge/HardcoreQuestingForge.java
+++ b/forge/src/main/java/hardcorequesting/forge/HardcoreQuestingForge.java
@@ -417,7 +417,7 @@ public class HardcoreQuestingForge implements AbstractPlatform {
     }
     
     @Override
-    public Supplier<Block> registerBlock(ResourceLocation resourceLocation, Supplier<Block> supplier) {
+    public <T extends Block> Supplier<T> registerBlock(ResourceLocation resourceLocation, Supplier<T> supplier) {
         return block.register(resourceLocation.getPath(), supplier);
     }
     
@@ -427,12 +427,12 @@ public class HardcoreQuestingForge implements AbstractPlatform {
     }
     
     @Override
-    public Supplier<Item> registerItem(ResourceLocation resourceLocation, Supplier<Item> supplier) {
+    public <T extends Item> Supplier<T> registerItem(ResourceLocation resourceLocation, Supplier<T> supplier) {
         return item.register(resourceLocation.getPath(), supplier);
     }
     
     @Override
-    public Supplier<BlockEntityType<?>> registerBlockEntity(ResourceLocation resourceLocation, BiFunction<BlockPos, BlockState, ? extends BlockEntity> constructor) {
+    public <T extends BlockEntity> Supplier<BlockEntityType<T>> registerBlockEntity(ResourceLocation resourceLocation, BiFunction<BlockPos, BlockState, T> constructor) {
         return tileEntityType.register(resourceLocation.getPath(), () -> BlockEntityType.Builder.of(constructor::apply).build(null));
     }
 }

--- a/forge/src/main/java/hardcorequesting/forge/HardcoreQuestingForge.java
+++ b/forge/src/main/java/hardcorequesting/forge/HardcoreQuestingForge.java
@@ -338,11 +338,6 @@ public class HardcoreQuestingForge implements AbstractPlatform {
     }
     
     @Override
-    public void setCraftingRemainingItem(Item item, Item item1) {
-        item.craftingRemainingItem = item1;
-    }
-    
-    @Override
     public FluidStack createEmptyFluidStack() {
         return new ForgeFluidStack();
     }

--- a/forge/src/main/java/hardcorequesting/forge/HardcoreQuestingForge.java
+++ b/forge/src/main/java/hardcorequesting/forge/HardcoreQuestingForge.java
@@ -413,26 +413,26 @@ public class HardcoreQuestingForge implements AbstractPlatform {
     
     @Override
     public Fraction getBucketAmount() {
-        return Fraction.ofWhole(1000);
+        return Fraction.ofWhole(FluidAttributes.BUCKET_VOLUME);
     }
     
     @Override
-    public <T extends Block> Supplier<T> registerBlock(ResourceLocation resourceLocation, Supplier<T> supplier) {
-        return block.register(resourceLocation.getPath(), supplier);
+    public <T extends Block> Supplier<T> registerBlock(String id, Supplier<T> supplier) {
+        return block.register(id, supplier);
     }
     
     @Override
-    public Supplier<SoundEvent> registerSound(ResourceLocation resourceLocation, Supplier<SoundEvent> supplier) {
-        return sounds.register(resourceLocation.getPath(), supplier);
+    public Supplier<SoundEvent> registerSound(String id, Supplier<SoundEvent> supplier) {
+        return sounds.register(id, supplier);
     }
     
     @Override
-    public <T extends Item> Supplier<T> registerItem(ResourceLocation resourceLocation, Supplier<T> supplier) {
-        return item.register(resourceLocation.getPath(), supplier);
+    public <T extends Item> Supplier<T> registerItem(String id, Supplier<T> supplier) {
+        return item.register(id, supplier);
     }
     
     @Override
-    public <T extends BlockEntity> Supplier<BlockEntityType<T>> registerBlockEntity(ResourceLocation resourceLocation, BiFunction<BlockPos, BlockState, T> constructor) {
-        return tileEntityType.register(resourceLocation.getPath(), () -> BlockEntityType.Builder.of(constructor::apply).build(null));
+    public <T extends BlockEntity> Supplier<BlockEntityType<T>> registerBlockEntity(String id, BiFunction<BlockPos, BlockState, T> constructor) {
+        return tileEntityType.register(id, () -> BlockEntityType.Builder.of(constructor::apply).build(null));
     }
 }

--- a/forge/src/main/resources/META-INF/accesstransformer.cfg
+++ b/forge/src/main/resources/META-INF/accesstransformer.cfg
@@ -1,1 +1,0 @@
-public-f net.minecraft.world.item.Item f_41378_ #craftingRemainingItem


### PR DESCRIPTION
The goal for this PR was to replace the access transformer for craftingRemainingItem.
To achieve this, I created a new type of recipe which doesn't consume any HQM books used in it.
There were also some cleanup on how objects were registered.

This does mean that any recipes from associated datapacks that uses our books will change in behavior. I do however think that this is acceptable as we've not yet made a full release version of the mod for 1.17.