### PR TITLE
[backport] Fix place block task consuming items instead of observing items

### DIFF
--- a/common/src/main/java/hardcorequesting/common/quests/task/item/PlaceBlockTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/item/PlaceBlockTask.java
@@ -36,7 +36,9 @@ public class PlaceBlockTask extends ItemRequirementTask {
     private void handleRightClick(InteractionHand hand, Player player, ItemStack itemStack) {
         if (hand != InteractionHand.MAIN_HAND) return;
         
-        NonNullList<ItemStack> consume = NonNullList.withSize(1, itemStack);
+        ItemStack placed = itemStack.copy();
+        placed.setCount(1);
+        NonNullList<ItemStack> consume = NonNullList.withSize(1, placed);
         increaseItems(consume, player.getUUID());
     }
 }


### PR DESCRIPTION
Backports 6044d15400c602bbaad949f88bdcb9bee24a09bd from #580 to 1.16. Fixes a possible cause to #590.