### PR TITLE
Mod loading tweaks

### DIFF
--- a/common/src/main/java/hardcorequesting/common/HardcoreQuestingCore.java
+++ b/common/src/main/java/hardcorequesting/common/HardcoreQuestingCore.java
@@ -54,7 +54,7 @@ public class HardcoreQuestingCore {
         } catch (IOException e) {
             e.printStackTrace();
         }
-        QuestLine.reset(Optional.of(packDir), Optional.of(dataDir)).loadAll();
+        QuestLine.reset(Optional.of(packDir), Optional.of(dataDir));
         
         HQMConfig.loadConfig();
         

--- a/common/src/main/java/hardcorequesting/common/quests/QuestSetsManager.java
+++ b/common/src/main/java/hardcorequesting/common/quests/QuestSetsManager.java
@@ -124,5 +124,6 @@ public class QuestSetsManager implements Serializable {
         } catch (IOException e) {
             HardcoreQuestingCore.LOGGER.warn("Failed loading quest sets for remote", e);
         }
+        HardcoreQuestingCore.LOGGER.info("Loaded %d quests from %d quest sets.", quests.size(), questSets.size());
     }
 }

--- a/common/src/main/java/hardcorequesting/common/quests/QuestingDataManager.java
+++ b/common/src/main/java/hardcorequesting/common/quests/QuestingDataManager.java
@@ -11,6 +11,7 @@ import hardcorequesting.common.io.SaveHandler;
 import hardcorequesting.common.items.ModItems;
 import hardcorequesting.common.team.TeamManager;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
@@ -63,14 +64,10 @@ public class QuestingDataManager {
     }
     
     public void activateHardcore() {
-        Boolean hardCore = null;
-        try {
-            hardCore = HardcoreQuestingCore.getServer().isHardcore();
-        } catch (Exception e) {
-            e.printStackTrace(); // todo exception handling
-        }
-        if (hardCore != null) {
-            if (!hardcoreActive && !hardCore) {
+        MinecraftServer server = HardcoreQuestingCore.getServer();
+        
+        if (server != null) {
+            if (!hardcoreActive && !server.isHardcore()) {
                 hardcoreActive = true;
             }
         }


### PR DESCRIPTION
Closes #592 in two ways:
- Instead of logging an exception in `QuestingDataManager.activateHardcore()` when the minecraft server is absent, do a normal null check instead
- Stopped an early load of HQM data that was happening during mod initialization (loading was also happening on world load, so there was little reason to have this early load)