### PR TITLE
5.7.1 Fix server-side crash

### DIFF
--- a/fabric/src/main/java/hardcorequesting/fabric/HardcoreQuestingFabric.java
+++ b/fabric/src/main/java/hardcorequesting/fabric/HardcoreQuestingFabric.java
@@ -28,6 +28,7 @@ import hardcorequesting.common.util.Fraction;
 import hardcorequesting.fabric.capabilities.ModCapabilities;
 import hardcorequesting.fabric.tileentity.BarrelBlockEntity;
 import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.itemgroup.FabricItemGroupBuilder;
@@ -292,6 +293,7 @@ public class HardcoreQuestingFabric implements ModInitializer, AbstractPlatform 
     }
     
     @Override
+    @Environment(EnvType.CLIENT)
     public void renderFluidStack(FluidStack fluid, PoseStack matrices, int x1, int y1, int x2, int y2) {
         // Behaves like FluidVolume.renderGuiRect(), but uses the provided PoseStack
         List<FluidRenderFace> faces = new ArrayList<>();

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.jvmargs=-Xmx4G
 
-mod_version=5.7.0
+mod_version=5.7.1
 maven_group=me.shedaniel
 archives_base_name=HQM
 


### PR DESCRIPTION
The function in question was missing an annotation since a while back. We had however ended up avoiding class-loading issues up until #591 after which it would cause a server-side crash.
This closes #611.
Suggesting this as a good point to make a new release since this is an important fix, and we've already got a few changes waiting.