### PR TITLE
Quest task changes

### DIFF
--- a/common/src/main/java/hardcorequesting/common/client/interfaces/graphic/QuestGraphic.java
+++ b/common/src/main/java/hardcorequesting/common/client/interfaces/graphic/QuestGraphic.java
@@ -57,8 +57,9 @@ public final class QuestGraphic extends EditableGraphic {
     private List<FormattedText> cachedDescription;
     
     {
-        for (final TaskType taskType : TaskType.values()) {
-            addButton(new LargeButton(gui, taskType.getLangKeyName(), taskType.getLangKeyDescription(), 185 + (taskType.ordinal() % 2) * 65, 50 + (taskType.ordinal() / 2) * 20) {
+        int ordinal = 0;
+        for (final TaskType<?> taskType : TaskType.values()) {
+            addButton(new LargeButton(gui, taskType.getLangKeyName(), taskType.getLangKeyDescription(), 185 + (ordinal % 2) * 65, 50 + (ordinal / 2) * 20) {
                 @Override
                 public boolean isVisible() {
                     return Quest.canQuestsBeEdited() && selectedTask == null && QuestGraphic.this.gui.getCurrentMode() == EditMode.TASK;
@@ -69,6 +70,7 @@ public final class QuestGraphic extends EditableGraphic {
                     taskType.addTask(quest);
                 }
             });
+            ordinal++;
         }
     }
     

--- a/common/src/main/java/hardcorequesting/common/client/interfaces/graphic/QuestGraphic.java
+++ b/common/src/main/java/hardcorequesting/common/client/interfaces/graphic/QuestGraphic.java
@@ -7,6 +7,7 @@ import hardcorequesting.common.client.interfaces.GuiQuestBook;
 import hardcorequesting.common.client.interfaces.edit.GuiEditMenuCommandEditor;
 import hardcorequesting.common.client.interfaces.edit.TextMenu;
 import hardcorequesting.common.client.interfaces.graphic.task.TaskGraphic;
+import hardcorequesting.common.client.interfaces.graphic.task.TaskGraphics;
 import hardcorequesting.common.client.interfaces.widget.ExtendedScrollBar;
 import hardcorequesting.common.client.interfaces.widget.LargeButton;
 import hardcorequesting.common.client.interfaces.widget.ScrollBar;
@@ -287,7 +288,7 @@ public final class QuestGraphic extends EditableGraphic {
     
     private void setSelectedTask(@Nullable QuestTask<?> task) {
         selectedTask = task;
-        taskGraphic = task == null ? null : task.createGraphic(playerId, gui);
+        taskGraphic = task == null ? null : TaskGraphics.create(task, playerId, gui);
     }
     
     @Override

--- a/common/src/main/java/hardcorequesting/common/client/interfaces/graphic/task/AdvancementTaskGraphic.java
+++ b/common/src/main/java/hardcorequesting/common/client/interfaces/graphic/task/AdvancementTaskGraphic.java
@@ -4,7 +4,6 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import hardcorequesting.common.client.EditMode;
 import hardcorequesting.common.client.interfaces.GuiQuestBook;
 import hardcorequesting.common.client.interfaces.edit.PickAdvancementMenu;
-import hardcorequesting.common.quests.task.PartList;
 import hardcorequesting.common.quests.task.icon.GetAdvancementTask;
 import hardcorequesting.common.util.Translator;
 import net.fabricmc.api.EnvType;
@@ -18,8 +17,8 @@ public class AdvancementTaskGraphic extends IconTaskGraphic<GetAdvancementTask.P
     
     private final GetAdvancementTask task;
     
-    public AdvancementTaskGraphic(GetAdvancementTask task, PartList<GetAdvancementTask.Part> parts, UUID playerId, GuiQuestBook gui) {
-        super(task, parts, playerId, gui);
+    public AdvancementTaskGraphic(GetAdvancementTask task, UUID playerId, GuiQuestBook gui) {
+        super(task, playerId, gui);
         this.task = task;
         addDetectButton(task);
     }

--- a/common/src/main/java/hardcorequesting/common/client/interfaces/graphic/task/CompleteQuestTaskGraphic.java
+++ b/common/src/main/java/hardcorequesting/common/client/interfaces/graphic/task/CompleteQuestTaskGraphic.java
@@ -5,7 +5,6 @@ import hardcorequesting.common.client.EditMode;
 import hardcorequesting.common.client.interfaces.GuiQuestBook;
 import hardcorequesting.common.quests.Quest;
 import hardcorequesting.common.quests.task.CompleteQuestTask;
-import hardcorequesting.common.quests.task.PartList;
 import hardcorequesting.common.util.EditType;
 import hardcorequesting.common.util.Positioned;
 import hardcorequesting.common.util.SaveHelper;
@@ -28,8 +27,8 @@ public class CompleteQuestTaskGraphic extends ListTaskGraphic<CompleteQuestTask.
     
     private final CompleteQuestTask task;
     
-    public CompleteQuestTaskGraphic(CompleteQuestTask task, PartList<CompleteQuestTask.Part> parts, UUID playerId, GuiQuestBook gui) {
-        super(task, parts, playerId, gui);
+    public CompleteQuestTaskGraphic(CompleteQuestTask task, UUID playerId, GuiQuestBook gui) {
+        super(task, task.getParts(), playerId, gui);
         this.task = task;
         addDetectButton(task);
     }

--- a/common/src/main/java/hardcorequesting/common/client/interfaces/graphic/task/IconTaskGraphic.java
+++ b/common/src/main/java/hardcorequesting/common/client/interfaces/graphic/task/IconTaskGraphic.java
@@ -5,7 +5,6 @@ import hardcorequesting.common.client.EditMode;
 import hardcorequesting.common.client.interfaces.GuiQuestBook;
 import hardcorequesting.common.client.interfaces.edit.PickItemMenu;
 import hardcorequesting.common.client.interfaces.edit.TextMenu;
-import hardcorequesting.common.quests.task.PartList;
 import hardcorequesting.common.quests.task.icon.IconLayoutTask;
 import hardcorequesting.common.util.Positioned;
 import hardcorequesting.common.util.Translator;
@@ -26,8 +25,8 @@ public abstract class IconTaskGraphic<Part extends IconLayoutTask.Part> extends 
     
     private final IconLayoutTask<Part, ?> task;
     
-    public IconTaskGraphic(IconLayoutTask<Part, ?> task, PartList<Part> parts, UUID playerId, GuiQuestBook gui) {
-        super(task, parts, playerId, gui);
+    public IconTaskGraphic(IconLayoutTask<Part, ?> task, UUID playerId, GuiQuestBook gui) {
+        super(task, task.getParts(), playerId, gui);
         this.task = task;
     }
     

--- a/common/src/main/java/hardcorequesting/common/client/interfaces/graphic/task/ItemTaskGraphic.java
+++ b/common/src/main/java/hardcorequesting/common/client/interfaces/graphic/task/ItemTaskGraphic.java
@@ -11,7 +11,6 @@ import hardcorequesting.common.network.GeneralUsage;
 import hardcorequesting.common.quests.Quest;
 import hardcorequesting.common.quests.QuestingData;
 import hardcorequesting.common.quests.QuestingDataManager;
-import hardcorequesting.common.quests.task.PartList;
 import hardcorequesting.common.quests.task.item.ItemRequirementTask;
 import hardcorequesting.common.util.OPBookHelper;
 import hardcorequesting.common.util.Positioned;
@@ -43,19 +42,19 @@ public class ItemTaskGraphic extends ListTaskGraphic<ItemRequirementTask.Part> {
     
     private final ItemRequirementTask task;
     
-    public ItemTaskGraphic(ItemRequirementTask task, PartList<ItemRequirementTask.Part> parts, UUID playerId, GuiQuestBook gui) {
-        super(task, parts, playerId, gui);
+    public ItemTaskGraphic(ItemRequirementTask task, UUID playerId, GuiQuestBook gui) {
+        super(task, task.getParts(), playerId, gui);
         this.task = task;
     }
     
-    public static ItemTaskGraphic createDetectGraphic(ItemRequirementTask task, PartList<ItemRequirementTask.Part> parts, UUID playerId, GuiQuestBook gui) {
-        ItemTaskGraphic graphic = new ItemTaskGraphic(task, parts, playerId, gui);
+    public static ItemTaskGraphic createDetectGraphic(ItemRequirementTask task, UUID playerId, GuiQuestBook gui) {
+        ItemTaskGraphic graphic = new ItemTaskGraphic(task, playerId, gui);
         graphic.addDetectButton(task);
         return graphic;
     }
     
-    public static ItemTaskGraphic createConsumeGraphic(ItemRequirementTask task, PartList<ItemRequirementTask.Part> parts, UUID playerId, GuiQuestBook gui, boolean hasSubmitButton) {
-        ItemTaskGraphic graphic = new ItemTaskGraphic(task, parts, playerId, gui);
+    public static ItemTaskGraphic createConsumeGraphic(ItemRequirementTask task, UUID playerId, GuiQuestBook gui, boolean hasSubmitButton) {
+        ItemTaskGraphic graphic = new ItemTaskGraphic(task, playerId, gui);
         if (hasSubmitButton)
             graphic.addSubmitButton(task);
     

--- a/common/src/main/java/hardcorequesting/common/client/interfaces/graphic/task/KillMobsTaskGraphic.java
+++ b/common/src/main/java/hardcorequesting/common/client/interfaces/graphic/task/KillMobsTaskGraphic.java
@@ -4,7 +4,6 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import hardcorequesting.common.client.EditMode;
 import hardcorequesting.common.client.interfaces.GuiQuestBook;
 import hardcorequesting.common.client.interfaces.edit.PickMobMenu;
-import hardcorequesting.common.quests.task.PartList;
 import hardcorequesting.common.quests.task.icon.KillMobsTask;
 import hardcorequesting.common.util.Translator;
 import net.fabricmc.api.EnvType;
@@ -18,8 +17,8 @@ public class KillMobsTaskGraphic extends IconTaskGraphic<KillMobsTask.Part> {
     
     private final KillMobsTask task;
     
-    public KillMobsTaskGraphic(KillMobsTask task, PartList<KillMobsTask.Part> parts, UUID playerId, GuiQuestBook gui) {
-        super(task, parts, playerId, gui);
+    public KillMobsTaskGraphic(KillMobsTask task, UUID playerId, GuiQuestBook gui) {
+        super(task, playerId, gui);
         this.task = task;
     }
     

--- a/common/src/main/java/hardcorequesting/common/client/interfaces/graphic/task/KillReputationTaskGraphic.java
+++ b/common/src/main/java/hardcorequesting/common/client/interfaces/graphic/task/KillReputationTaskGraphic.java
@@ -5,9 +5,7 @@ import hardcorequesting.common.client.interfaces.GuiQuestBook;
 import hardcorequesting.common.client.interfaces.edit.IntInputMenu;
 import hardcorequesting.common.client.interfaces.widget.LargeButton;
 import hardcorequesting.common.quests.Quest;
-import hardcorequesting.common.quests.task.PartList;
 import hardcorequesting.common.quests.task.reputation.KillReputationTask;
-import hardcorequesting.common.quests.task.reputation.ReputationTask;
 import hardcorequesting.common.util.Translator;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
@@ -20,8 +18,8 @@ public class KillReputationTaskGraphic extends ReputationTaskGraphic {
     
     private final KillReputationTask task;
     
-    public KillReputationTaskGraphic(KillReputationTask task, PartList<ReputationTask.Part> parts, UUID playerId, GuiQuestBook gui) {
-        super(task, parts, playerId, gui, 20);
+    public KillReputationTaskGraphic(KillReputationTask task, UUID playerId, GuiQuestBook gui) {
+        super(task, playerId, gui, 20);
         this.task = task;
         
         addButton(new LargeButton(gui, "hqm.quest.requirement", 250, 95) {

--- a/common/src/main/java/hardcorequesting/common/client/interfaces/graphic/task/LocationTaskGraphic.java
+++ b/common/src/main/java/hardcorequesting/common/client/interfaces/graphic/task/LocationTaskGraphic.java
@@ -4,7 +4,6 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import hardcorequesting.common.client.EditMode;
 import hardcorequesting.common.client.interfaces.GuiQuestBook;
 import hardcorequesting.common.client.interfaces.edit.LocationMenu;
-import hardcorequesting.common.quests.task.PartList;
 import hardcorequesting.common.quests.task.icon.VisitLocationTask;
 import hardcorequesting.common.util.Translator;
 import net.fabricmc.api.EnvType;
@@ -21,8 +20,8 @@ public class LocationTaskGraphic extends IconTaskGraphic<VisitLocationTask.Part>
     
     private final VisitLocationTask task;
     
-    public LocationTaskGraphic(VisitLocationTask task, PartList<VisitLocationTask.Part> parts, UUID playerId, GuiQuestBook gui) {
-        super(task, parts, playerId, gui);
+    public LocationTaskGraphic(VisitLocationTask task, UUID playerId, GuiQuestBook gui) {
+        super(task, playerId, gui);
         this.task = task;
     }
     

--- a/common/src/main/java/hardcorequesting/common/client/interfaces/graphic/task/ReputationTaskGraphic.java
+++ b/common/src/main/java/hardcorequesting/common/client/interfaces/graphic/task/ReputationTaskGraphic.java
@@ -5,7 +5,6 @@ import hardcorequesting.common.client.EditMode;
 import hardcorequesting.common.client.interfaces.GuiQuestBook;
 import hardcorequesting.common.client.interfaces.ResourceHelper;
 import hardcorequesting.common.client.interfaces.edit.GuiEditMenuReputationSetting;
-import hardcorequesting.common.quests.task.PartList;
 import hardcorequesting.common.quests.task.reputation.ReputationTask;
 import hardcorequesting.common.reputation.Reputation;
 import hardcorequesting.common.util.Positioned;
@@ -26,12 +25,12 @@ public class ReputationTaskGraphic extends ListTaskGraphic<ReputationTask.Part> 
     
     private final ReputationTask<?> task;
     
-    public ReputationTaskGraphic(ReputationTask<?> task, PartList<ReputationTask.Part> parts, UUID playerId, GuiQuestBook gui) {
-        this(task, parts, playerId, gui, 0);
+    public ReputationTaskGraphic(ReputationTask<?> task, UUID playerId, GuiQuestBook gui) {
+        this(task, playerId, gui, 0);
     }
     
-    protected ReputationTaskGraphic(ReputationTask<?> task, PartList<ReputationTask.Part> parts, UUID playerId, GuiQuestBook gui, int startOffsetY) {
-        super(task, parts, playerId, gui);
+    protected ReputationTaskGraphic(ReputationTask<?> task, UUID playerId, GuiQuestBook gui, int startOffsetY) {
+        super(task, task.getParts(), playerId, gui);
         this.task = task;
         this.startOffsetY = startOffsetY;
     }

--- a/common/src/main/java/hardcorequesting/common/client/interfaces/graphic/task/TameMobsTaskGraphic.java
+++ b/common/src/main/java/hardcorequesting/common/client/interfaces/graphic/task/TameMobsTaskGraphic.java
@@ -4,7 +4,6 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import hardcorequesting.common.client.EditMode;
 import hardcorequesting.common.client.interfaces.GuiQuestBook;
 import hardcorequesting.common.client.interfaces.edit.PickMobMenu;
-import hardcorequesting.common.quests.task.PartList;
 import hardcorequesting.common.quests.task.icon.TameMobsTask;
 import hardcorequesting.common.util.Translator;
 import net.fabricmc.api.EnvType;
@@ -19,8 +18,8 @@ public class TameMobsTaskGraphic extends IconTaskGraphic<TameMobsTask.Part> {
     
     private final TameMobsTask task;
     
-    public TameMobsTaskGraphic(TameMobsTask task, PartList<TameMobsTask.Part> parts, UUID playerId, GuiQuestBook gui) {
-        super(task, parts, playerId, gui);
+    public TameMobsTaskGraphic(TameMobsTask task, UUID playerId, GuiQuestBook gui) {
+        super(task, playerId, gui);
         this.task = task;
     }
     

--- a/common/src/main/java/hardcorequesting/common/client/interfaces/graphic/task/TaskGraphic.java
+++ b/common/src/main/java/hardcorequesting/common/client/interfaces/graphic/task/TaskGraphic.java
@@ -7,6 +7,7 @@ import hardcorequesting.common.client.interfaces.GuiBase;
 import hardcorequesting.common.client.interfaces.GuiQuestBook;
 import hardcorequesting.common.client.interfaces.edit.TextMenu;
 import hardcorequesting.common.client.interfaces.graphic.Graphic;
+import hardcorequesting.common.client.interfaces.widget.ExtendedScrollBar;
 import hardcorequesting.common.client.interfaces.widget.LargeButton;
 import hardcorequesting.common.client.interfaces.widget.ScrollBar;
 import hardcorequesting.common.network.NetworkManager;
@@ -26,7 +27,7 @@ public abstract class TaskGraphic extends Graphic {
     private static final int TASK_DESCRIPTION_X = 180;
     private static final int TASK_DESCRIPTION_Y = 20;
     
-    private final ScrollBar taskDescriptionScroll;
+    private final ExtendedScrollBar<FormattedText> taskDescriptionScroll;
     
     protected final UUID playerId;
     protected final GuiQuestBook gui;
@@ -38,12 +39,7 @@ public abstract class TaskGraphic extends Graphic {
         this.gui = gui;
         this.task = task;
         
-        addScrollBar(taskDescriptionScroll = new ScrollBar(gui, ScrollBar.Size.SMALL, 312, 18, TASK_DESCRIPTION_X) {
-            @Override
-            public boolean isVisible() {
-                return getCachedLongDescription().size() > VISIBLE_DESCRIPTION_LINES;
-            }
-        });
+        addScrollBar(taskDescriptionScroll = new ExtendedScrollBar<>(gui, ScrollBar.Size.SMALL, 312, 18, TASK_DESCRIPTION_X, VISIBLE_DESCRIPTION_LINES, this::getCachedLongDescription));
     }
     
     protected void addSubmitButton(QuestTask<?> task) {
@@ -77,9 +73,9 @@ public abstract class TaskGraphic extends Graphic {
     @Override
     public void draw(PoseStack matrices, int mX, int mY) {
         super.draw(matrices, mX, mY);
-        
-        List<FormattedText> description = taskDescriptionScroll.getVisibleEntries(getCachedLongDescription(), VISIBLE_DESCRIPTION_LINES);
-        gui.drawString(matrices, description, TASK_DESCRIPTION_X, TASK_DESCRIPTION_Y, 0.7F, 0x404040);
+    
+        gui.drawString(matrices, taskDescriptionScroll.getVisibleEntries(),
+                TASK_DESCRIPTION_X, TASK_DESCRIPTION_Y, 0.7F, 0x404040);
     }
     
     @Override

--- a/common/src/main/java/hardcorequesting/common/client/interfaces/graphic/task/TaskGraphic.java
+++ b/common/src/main/java/hardcorequesting/common/client/interfaces/graphic/task/TaskGraphic.java
@@ -31,6 +31,7 @@ public abstract class TaskGraphic extends Graphic {
     protected final UUID playerId;
     protected final GuiQuestBook gui;
     private final QuestTask<?> task;
+    private List<FormattedText> cachedDescription;
     
     protected TaskGraphic(UUID playerId, GuiQuestBook gui, QuestTask<?> task) {
         this.playerId = playerId;
@@ -40,7 +41,7 @@ public abstract class TaskGraphic extends Graphic {
         addScrollBar(taskDescriptionScroll = new ScrollBar(gui, ScrollBar.Size.SMALL, 312, 18, TASK_DESCRIPTION_X) {
             @Override
             public boolean isVisible() {
-                return task.getCachedLongDescription(gui).size() > VISIBLE_DESCRIPTION_LINES;
+                return getCachedLongDescription().size() > VISIBLE_DESCRIPTION_LINES;
             }
         });
     }
@@ -77,7 +78,7 @@ public abstract class TaskGraphic extends Graphic {
     public void draw(PoseStack matrices, int mX, int mY) {
         super.draw(matrices, mX, mY);
         
-        List<FormattedText> description = taskDescriptionScroll.getVisibleEntries(task.getCachedLongDescription(gui), VISIBLE_DESCRIPTION_LINES);
+        List<FormattedText> description = taskDescriptionScroll.getVisibleEntries(getCachedLongDescription(), VISIBLE_DESCRIPTION_LINES);
         gui.drawString(matrices, description, TASK_DESCRIPTION_X, TASK_DESCRIPTION_Y, 0.7F, 0x404040);
     }
     
@@ -85,7 +86,20 @@ public abstract class TaskGraphic extends Graphic {
     public void onClick(int mX, int mY, int b) {
         super.onClick(mX, mY, b);
         if (gui.getCurrentMode() == EditMode.RENAME && gui.inBounds(TASK_DESCRIPTION_X, TASK_DESCRIPTION_Y, 130, (int) (VISIBLE_DESCRIPTION_LINES * GuiBase.TEXT_HEIGHT * 0.7), mX, mY)) {
-            TextMenu.display(gui, playerId, task.getLangKeyLongDescription(), false, task::setLongDescription);
+            TextMenu.display(gui, playerId, task.getLangKeyLongDescription(), false, this::setLongDescription);
         }
+    }
+    
+    private List<FormattedText> getCachedLongDescription() {
+        if (cachedDescription == null) {
+            cachedDescription = gui.getLinesFromText(task.getLongDescription(), 0.7F, 130);
+        }
+        
+        return cachedDescription;
+    }
+    
+    private void setLongDescription(String description) {
+        task.setLongDescription(description);
+        cachedDescription = null;
     }
 }

--- a/common/src/main/java/hardcorequesting/common/client/interfaces/graphic/task/TaskGraphics.java
+++ b/common/src/main/java/hardcorequesting/common/client/interfaces/graphic/task/TaskGraphics.java
@@ -1,0 +1,28 @@
+package hardcorequesting.common.client.interfaces.graphic.task;
+
+import hardcorequesting.common.client.interfaces.GuiQuestBook;
+import hardcorequesting.common.quests.task.QuestTask;
+import hardcorequesting.common.quests.task.TaskType;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class TaskGraphics {
+    
+    private static final Map<TaskType<?>, Constructor<?>> constructors = new HashMap<>();
+    
+    public static <T extends QuestTask<?>> void register(TaskType<T> type, Constructor<? super T> constructor) {
+        constructors.put(type, constructor);
+    }
+    
+    public static <T extends QuestTask<?>> TaskGraphic create(T task, UUID playerId, GuiQuestBook questBook) {
+        @SuppressWarnings("unchecked")
+        Constructor<? super T> constructor = (Constructor<? super T>) constructors.get(task.getType());
+        return constructor.create(task, playerId, questBook);
+    }
+    
+    public interface Constructor<T extends QuestTask<?>> {
+        TaskGraphic create(T task, UUID playerId, GuiQuestBook questBook);
+    }
+}

--- a/common/src/main/java/hardcorequesting/common/io/adapter/QuestTaskAdapter.java
+++ b/common/src/main/java/hardcorequesting/common/io/adapter/QuestTaskAdapter.java
@@ -382,10 +382,10 @@ public class QuestTaskAdapter {
     
         @Override
         public JsonElement serialize(QuestTask<?> src) {
-            TaskType type = TaskType.getType(src.getClass());
+            TaskType<?> type = TaskType.getType(src.getClass());
         
             JsonObjectBuilder builder = object()
-                    .add(TYPE, type.name());
+                    .add(TYPE, type.toDataName());
             if (!src.getLangKeyDescription().equals(type.getLangKeyName()))
                 builder.add(DESCRIPTION, src.getLangKeyDescription());
             if (!src.getLangKeyLongDescription().equals(type.getLangKeyDescription()))
@@ -397,7 +397,7 @@ public class QuestTaskAdapter {
         @Override
         public QuestTask<?> deserialize(JsonElement json) {
             JsonObject object = json.getAsJsonObject();
-            TaskType type = TaskType.valueOf(GsonHelper.getAsString(object, TYPE));
+            TaskType<?> type = TaskType.fromDataName(GsonHelper.getAsString(object, TYPE));
             QuestTask<?> TASK = type.addTask(QUEST);
             if (object.has(DESCRIPTION)) TASK.setDescription(GsonHelper.getAsString(object, DESCRIPTION));
             if (object.has(LONG_DESCRIPTION)) TASK.setLongDescription(GsonHelper.getAsString(object, LONG_DESCRIPTION));

--- a/common/src/main/java/hardcorequesting/common/io/adapter/QuestTaskAdapter.java
+++ b/common/src/main/java/hardcorequesting/common/io/adapter/QuestTaskAdapter.java
@@ -382,7 +382,7 @@ public class QuestTaskAdapter {
     
         @Override
         public JsonElement serialize(QuestTask<?> src) {
-            TaskType<?> type = TaskType.getType(src.getClass());
+            TaskType<?> type = src.getType();
         
             JsonObjectBuilder builder = object()
                     .add(TYPE, type.toDataName());

--- a/common/src/main/java/hardcorequesting/common/proxies/ClientProxy.java
+++ b/common/src/main/java/hardcorequesting/common/proxies/ClientProxy.java
@@ -1,9 +1,11 @@
 package hardcorequesting.common.proxies;
 
 import hardcorequesting.common.HardcoreQuestingCore;
+import hardcorequesting.common.client.interfaces.graphic.task.*;
 import hardcorequesting.common.network.PacketContext;
 import hardcorequesting.common.quests.Quest;
 import hardcorequesting.common.quests.QuestTicker;
+import hardcorequesting.common.quests.task.TaskType;
 import net.minecraft.client.Minecraft;
 import net.minecraft.world.entity.player.Player;
 
@@ -14,6 +16,21 @@ public class ClientProxy extends CommonProxy {
         super.init();
         Quest.clientTicker = new QuestTicker();
         HardcoreQuestingCore.platform.registerOnClientTick(minecraftClient -> Quest.clientTicker.tick(minecraftClient.level, true));
+    
+        TaskGraphics.register(TaskType.CONSUME, (task, playerId, questBook) -> ItemTaskGraphic.createConsumeGraphic(task, playerId, questBook, true));
+        TaskGraphics.register(TaskType.CRAFT, ItemTaskGraphic::new);
+        TaskGraphics.register(TaskType.LOCATION, LocationTaskGraphic::new);
+        TaskGraphics.register(TaskType.CONSUME_QDS, (task, playerId, questBook) -> ItemTaskGraphic.createConsumeGraphic(task, playerId, questBook, false));
+        TaskGraphics.register(TaskType.DETECT, ItemTaskGraphic::createDetectGraphic);
+        TaskGraphics.register(TaskType.KILL, KillMobsTaskGraphic::new);
+        TaskGraphics.register(TaskType.TAME, TameMobsTaskGraphic::new);
+        TaskGraphics.register(TaskType.DEATH, DeathTaskGraphic::new);
+        TaskGraphics.register(TaskType.REPUTATION, ReputationTaskGraphic::new);
+        TaskGraphics.register(TaskType.REPUTATION_KILL, KillReputationTaskGraphic::new);
+        TaskGraphics.register(TaskType.ADVANCEMENT, AdvancementTaskGraphic::new);
+        TaskGraphics.register(TaskType.COMPLETION, CompleteQuestTaskGraphic::new);
+        TaskGraphics.register(TaskType.BLOCK_BREAK, ItemTaskGraphic::new);
+        TaskGraphics.register(TaskType.BLOCK_PLACE, ItemTaskGraphic::new);
     }
     
     @Override

--- a/common/src/main/java/hardcorequesting/common/quests/task/CompleteQuestTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/CompleteQuestTask.java
@@ -30,8 +30,8 @@ public class CompleteQuestTask extends QuestTask<CompleteQuestTaskData> {
     
     private final PartList<Part> parts = new PartList<>(Part::new, EditType.Type.COMPLETION, LIMIT);
     
-    public CompleteQuestTask(Quest parent, String description, String longDescription) {
-        super(TaskType.COMPLETION, CompleteQuestTaskData.class, parent, description, longDescription);
+    public CompleteQuestTask(Quest parent) {
+        super(TaskType.COMPLETION, CompleteQuestTaskData.class, parent);
         
         register(EventTrigger.Type.QUEST_COMPLETED, EventTrigger.Type.OPEN_BOOK);
     }

--- a/common/src/main/java/hardcorequesting/common/quests/task/CompleteQuestTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/CompleteQuestTask.java
@@ -3,9 +3,6 @@ package hardcorequesting.common.quests.task;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.mojang.datafixers.util.Either;
-import hardcorequesting.common.client.interfaces.GuiQuestBook;
-import hardcorequesting.common.client.interfaces.graphic.task.CompleteQuestTaskGraphic;
-import hardcorequesting.common.client.interfaces.graphic.task.TaskGraphic;
 import hardcorequesting.common.event.EventTrigger;
 import hardcorequesting.common.io.adapter.Adapter;
 import hardcorequesting.common.io.adapter.QuestTaskAdapter;
@@ -14,8 +11,6 @@ import hardcorequesting.common.quests.Quest;
 import hardcorequesting.common.quests.data.CompleteQuestTaskData;
 import hardcorequesting.common.team.Team;
 import hardcorequesting.common.util.EditType;
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.minecraft.util.GsonHelper;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
@@ -36,10 +31,8 @@ public class CompleteQuestTask extends QuestTask<CompleteQuestTaskData> {
         register(EventTrigger.Type.QUEST_COMPLETED, EventTrigger.Type.OPEN_BOOK);
     }
     
-    @Environment(EnvType.CLIENT)
-    @Override
-    public TaskGraphic createGraphic(UUID playerId, GuiQuestBook gui) {
-        return new CompleteQuestTaskGraphic(this, parts, playerId, gui);
+    public PartList<Part> getParts() {
+        return parts;
     }
     
     public boolean completed(int id, UUID playerId) {

--- a/common/src/main/java/hardcorequesting/common/quests/task/CompleteQuestTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/CompleteQuestTask.java
@@ -31,7 +31,7 @@ public class CompleteQuestTask extends QuestTask<CompleteQuestTaskData> {
     private final PartList<Part> parts = new PartList<>(Part::new, EditType.Type.COMPLETION, LIMIT);
     
     public CompleteQuestTask(Quest parent, String description, String longDescription) {
-        super(CompleteQuestTaskData.class, parent, description, longDescription);
+        super(TaskType.COMPLETION, CompleteQuestTaskData.class, parent, description, longDescription);
         
         register(EventTrigger.Type.QUEST_COMPLETED, EventTrigger.Type.OPEN_BOOK);
     }

--- a/common/src/main/java/hardcorequesting/common/quests/task/DeathTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/DeathTask.java
@@ -1,9 +1,6 @@
 package hardcorequesting.common.quests.task;
 
 import com.google.gson.JsonObject;
-import hardcorequesting.common.client.interfaces.GuiQuestBook;
-import hardcorequesting.common.client.interfaces.graphic.task.DeathTaskGraphic;
-import hardcorequesting.common.client.interfaces.graphic.task.TaskGraphic;
 import hardcorequesting.common.event.EventTrigger;
 import hardcorequesting.common.io.adapter.Adapter;
 import hardcorequesting.common.quests.Quest;
@@ -11,8 +8,6 @@ import hardcorequesting.common.quests.data.DeathTaskData;
 import hardcorequesting.common.team.Team;
 import hardcorequesting.common.util.EditType;
 import hardcorequesting.common.util.SaveHelper;
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.GsonHelper;
 import net.minecraft.world.damagesource.DamageSource;
@@ -30,12 +25,6 @@ public class DeathTask extends QuestTask<DeathTaskData> {
         super(TaskType.DEATH, DeathTaskData.class, parent);
         
         register(EventTrigger.Type.DEATH);
-    }
-    
-    @Environment(EnvType.CLIENT)
-    @Override
-    public TaskGraphic createGraphic(UUID playerId, GuiQuestBook gui) {
-        return new DeathTaskGraphic(this, playerId, gui);
     }
     
     @Override

--- a/common/src/main/java/hardcorequesting/common/quests/task/DeathTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/DeathTask.java
@@ -27,7 +27,7 @@ public class DeathTask extends QuestTask<DeathTaskData> {
     private int deaths;
     
     public DeathTask(Quest parent, String description, String longDescription) {
-        super(DeathTaskData.class, parent, description, longDescription);
+        super(TaskType.DEATH, DeathTaskData.class, parent, description, longDescription);
         
         register(EventTrigger.Type.DEATH);
     }

--- a/common/src/main/java/hardcorequesting/common/quests/task/DeathTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/DeathTask.java
@@ -26,8 +26,8 @@ public class DeathTask extends QuestTask<DeathTaskData> {
     private static final String DEATHS = "deaths";
     private int deaths;
     
-    public DeathTask(Quest parent, String description, String longDescription) {
-        super(TaskType.DEATH, DeathTaskData.class, parent, description, longDescription);
+    public DeathTask(Quest parent) {
+        super(TaskType.DEATH, DeathTaskData.class, parent);
         
         register(EventTrigger.Type.DEATH);
     }

--- a/common/src/main/java/hardcorequesting/common/quests/task/QuestTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/QuestTask.java
@@ -53,12 +53,12 @@ public abstract class QuestTask<Data extends TaskData> {
     private int id;
     private List<FormattedText> cachedDescription;
     
-    public QuestTask(TaskType<?> type, Class<Data> dataType, Quest parent, String description, String longDescription) {
+    public QuestTask(TaskType<?> type, Class<Data> dataType, Quest parent) {
         this.type = type;
         this.dataType = dataType;
         this.parent = parent;
-        this.description = description;
-        this.longDescription = longDescription;
+        this.description = type.getLangKeyName();
+        this.longDescription = type.getLangKeyDescription();
     }
     
     public TaskType<?> getType() {

--- a/common/src/main/java/hardcorequesting/common/quests/task/QuestTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/QuestTask.java
@@ -4,8 +4,6 @@ import com.google.gson.JsonObject;
 import com.google.gson.stream.JsonReader;
 import hardcorequesting.common.client.ClientChange;
 import hardcorequesting.common.client.interfaces.GuiBase;
-import hardcorequesting.common.client.interfaces.GuiQuestBook;
-import hardcorequesting.common.client.interfaces.graphic.task.TaskGraphic;
 import hardcorequesting.common.client.sounds.Sounds;
 import hardcorequesting.common.event.EventTrigger;
 import hardcorequesting.common.io.adapter.Adapter;
@@ -200,9 +198,6 @@ public abstract class QuestTask<Data extends TaskData> {
         getData(uuid).completed = true;
         completeQuest(parent, uuid);
     }
-    
-    @Environment(EnvType.CLIENT)
-    public abstract TaskGraphic createGraphic(UUID playerId, GuiQuestBook gui);
     
     public abstract void onUpdate(Player player);
     

--- a/common/src/main/java/hardcorequesting/common/quests/task/QuestTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/QuestTask.java
@@ -45,6 +45,7 @@ import java.util.UUID;
 
 public abstract class QuestTask<Data extends TaskData> {
     
+    private final TaskType<?> type;
     private final Class<Data> dataType;
     public String description;
     protected Quest parent;
@@ -52,11 +53,16 @@ public abstract class QuestTask<Data extends TaskData> {
     private int id;
     private List<FormattedText> cachedDescription;
     
-    public QuestTask(Class<Data> dataType, Quest parent, String description, String longDescription) {
+    public QuestTask(TaskType<?> type, Class<Data> dataType, Quest parent, String description, String longDescription) {
+        this.type = type;
         this.dataType = dataType;
         this.parent = parent;
         this.description = description;
         this.longDescription = longDescription;
+    }
+    
+    public TaskType<?> getType() {
+        return type;
     }
     
     public static void completeQuest(Quest quest, UUID uuid) {

--- a/common/src/main/java/hardcorequesting/common/quests/task/QuestTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/QuestTask.java
@@ -3,7 +3,6 @@ package hardcorequesting.common.quests.task;
 import com.google.gson.JsonObject;
 import com.google.gson.stream.JsonReader;
 import hardcorequesting.common.client.ClientChange;
-import hardcorequesting.common.client.interfaces.GuiBase;
 import hardcorequesting.common.client.sounds.Sounds;
 import hardcorequesting.common.event.EventTrigger;
 import hardcorequesting.common.io.adapter.Adapter;
@@ -21,8 +20,6 @@ import hardcorequesting.common.team.RewardSetting;
 import hardcorequesting.common.team.Team;
 import hardcorequesting.common.team.TeamLiteStat;
 import hardcorequesting.common.util.Translator;
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.FormattedText;
 import net.minecraft.network.chat.MutableComponent;
@@ -38,7 +35,6 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.UUID;
 
 public abstract class QuestTask<Data extends TaskData> {
@@ -49,7 +45,6 @@ public abstract class QuestTask<Data extends TaskData> {
     protected Quest parent;
     private String longDescription;
     private int id;
-    private List<FormattedText> cachedDescription;
     
     public QuestTask(TaskType<?> type, Class<Data> dataType, Quest parent) {
         this.type = type;
@@ -182,16 +177,6 @@ public abstract class QuestTask<Data extends TaskData> {
     
     public void setLongDescription(String longDescription) {
         this.longDescription = longDescription;
-        cachedDescription = null;
-    }
-    
-    @Environment(EnvType.CLIENT)
-    public List<FormattedText> getCachedLongDescription(GuiBase gui) {
-        if (cachedDescription == null) {
-            cachedDescription = gui.getLinesFromText(Translator.plain(longDescription), 0.7F, 130);
-        }
-        
-        return cachedDescription;
     }
     
     public void completeTask(UUID uuid) {

--- a/common/src/main/java/hardcorequesting/common/quests/task/TaskType.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/TaskType.java
@@ -33,10 +33,10 @@ public final class TaskType<T extends QuestTask<?>> {
     public static final TaskType<BreakBlockTask> BLOCK_BREAK = new TaskType<>("break", BreakBlockTask::new);
     public static final TaskType<PlaceBlockTask> BLOCK_PLACE = new TaskType<>("place", PlaceBlockTask::new);
     
-    private static final Map<String, TaskType<?>> TYPES = ImmutableMap.<String, TaskType<?>>builder().put("consume", CONSUME).put("craft", CRAFT)
-            .put("location", LOCATION).put("consume_qds", CONSUME_QDS).put("detect", DETECT).put("kill", KILL).put("tame", TAME).put("death", DEATH)
-            .put("reputation", REPUTATION).put("reputation_kill", REPUTATION_KILL).put("advancement", ADVANCEMENT).put("completion", COMPLETION)
-            .put("block_break", BLOCK_BREAK).put("block_place", BLOCK_PLACE).build();
+    private static final Map<String, TaskType<?>> TYPES = ImmutableMap.<String, TaskType<?>>builder().put("CONSUME", CONSUME).put("CRAFT", CRAFT)
+            .put("LOCATION", LOCATION).put("CONSUME_QDS", CONSUME_QDS).put("DETECT", DETECT).put("KILL", KILL).put("TAME", TAME).put("DEATH", DEATH)
+            .put("REPUTATION", REPUTATION).put("REPUTATION_KILL", REPUTATION_KILL).put("ADVANCEMENT", ADVANCEMENT).put("COMPLETION", COMPLETION)
+            .put("BLOCK_BREAK", BLOCK_BREAK).put("BLOCK_PLACE", BLOCK_PLACE).build();
     
     private final String id;
     private final TaskConstructor<T> constructor;
@@ -62,7 +62,7 @@ public final class TaskType<T extends QuestTask<?>> {
         TaskType<?> type = TYPES.get(str);
         if (type != null)
             return type;
-        else throw new IllegalArgumentException(str + "is not a valid task type name");
+        else throw new IllegalArgumentException(str + " is not a valid task type name");
     }
     
     public T addTask(Quest quest) {

--- a/common/src/main/java/hardcorequesting/common/quests/task/TaskType.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/TaskType.java
@@ -18,45 +18,36 @@ import java.util.Collection;
 import java.util.Map;
 
 public final class TaskType<T extends QuestTask<?>> {
-    public static final TaskType<ConsumeItemTask> CONSUME = new TaskType<>(ConsumeItemTask.class, "consume", ConsumeItemTask::new);
-    public static final TaskType<CraftingTask> CRAFT = new TaskType<>(CraftingTask.class, "craft", CraftingTask::new);
-    public static final TaskType<VisitLocationTask> LOCATION = new TaskType<>(VisitLocationTask.class, "location", VisitLocationTask::new);
-    public static final TaskType<ConsumeItemQDSTask> CONSUME_QDS = new TaskType<>(ConsumeItemQDSTask.class, "consumeQDS", ConsumeItemQDSTask::new);
-    public static final TaskType<DetectItemTask> DETECT = new TaskType<>(DetectItemTask.class, "detect", DetectItemTask::new);
-    public static final TaskType<KillMobsTask> KILL = new TaskType<>(KillMobsTask.class, "kill", KillMobsTask::new);
-    public static final TaskType<TameMobsTask> TAME = new TaskType<>(TameMobsTask.class, "tame", TameMobsTask::new);
-    public static final TaskType<DeathTask> DEATH = new TaskType<>(DeathTask.class, "death", DeathTask::new);
-    public static final TaskType<HaveReputationTask> REPUTATION = new TaskType<>(HaveReputationTask.class, "reputation", HaveReputationTask::new);
-    public static final TaskType<KillReputationTask> REPUTATION_KILL = new TaskType<>(KillReputationTask.class, "reputationKill", KillReputationTask::new);
-    public static final TaskType<GetAdvancementTask> ADVANCEMENT = new TaskType<>(GetAdvancementTask.class, "advancement", GetAdvancementTask::new);
-    public static final TaskType<CompleteQuestTask> COMPLETION = new TaskType<>(CompleteQuestTask.class, "completion", CompleteQuestTask::new);
-    public static final TaskType<BreakBlockTask> BLOCK_BREAK = new TaskType<>(BreakBlockTask.class, "break", BreakBlockTask::new);
-    public static final TaskType<PlaceBlockTask> BLOCK_PLACE = new TaskType<>(PlaceBlockTask.class, "place", PlaceBlockTask::new);
+    public static final TaskType<ConsumeItemTask> CONSUME = new TaskType<>("consume", ConsumeItemTask::new);
+    public static final TaskType<CraftingTask> CRAFT = new TaskType<>("craft", CraftingTask::new);
+    public static final TaskType<VisitLocationTask> LOCATION = new TaskType<>("location", VisitLocationTask::new);
+    public static final TaskType<ConsumeItemQDSTask> CONSUME_QDS = new TaskType<>("consumeQDS", ConsumeItemQDSTask::new);
+    public static final TaskType<DetectItemTask> DETECT = new TaskType<>("detect", DetectItemTask::new);
+    public static final TaskType<KillMobsTask> KILL = new TaskType<>("kill", KillMobsTask::new);
+    public static final TaskType<TameMobsTask> TAME = new TaskType<>("tame", TameMobsTask::new);
+    public static final TaskType<DeathTask> DEATH = new TaskType<>("death", DeathTask::new);
+    public static final TaskType<HaveReputationTask> REPUTATION = new TaskType<>("reputation", HaveReputationTask::new);
+    public static final TaskType<KillReputationTask> REPUTATION_KILL = new TaskType<>("reputationKill", KillReputationTask::new);
+    public static final TaskType<GetAdvancementTask> ADVANCEMENT = new TaskType<>("advancement", GetAdvancementTask::new);
+    public static final TaskType<CompleteQuestTask> COMPLETION = new TaskType<>("completion", CompleteQuestTask::new);
+    public static final TaskType<BreakBlockTask> BLOCK_BREAK = new TaskType<>("break", BreakBlockTask::new);
+    public static final TaskType<PlaceBlockTask> BLOCK_PLACE = new TaskType<>("place", PlaceBlockTask::new);
     
     private static final Map<String, TaskType<?>> TYPES = ImmutableMap.<String, TaskType<?>>builder().put("consume", CONSUME).put("craft", CRAFT)
             .put("location", LOCATION).put("consume_qds", CONSUME_QDS).put("detect", DETECT).put("kill", KILL).put("tame", TAME).put("death", DEATH)
             .put("reputation", REPUTATION).put("reputation_kill", REPUTATION_KILL).put("advancement", ADVANCEMENT).put("completion", COMPLETION)
             .put("block_break", BLOCK_BREAK).put("block_place", BLOCK_PLACE).build();
     
-    private final Class<T> clazz;
     private final String id;
     private final TaskConstructor<T> constructor;
     
-    private TaskType(Class<T> clazz, String id, TaskConstructor<T> constructor) {
-        this.clazz = clazz;
+    private TaskType(String id, TaskConstructor<T> constructor) {
         this.id = id;
         this.constructor = constructor;
     }
     
     public static Collection<TaskType<?>> values() {
         return TYPES.values();
-    }
-    
-    public static TaskType<?> getType(Class<?> clazz) {
-        for (TaskType<?> type : values()) {
-            if (type.clazz == clazz) return type;
-        }
-        throw new IllegalArgumentException(clazz.getName() + " does not have a valid task type");
     }
     
     public String toDataName() {

--- a/common/src/main/java/hardcorequesting/common/quests/task/TaskType.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/TaskType.java
@@ -66,7 +66,7 @@ public final class TaskType<T extends QuestTask<?>> {
     }
     
     public T addTask(Quest quest) {
-        T task = constructor.create(quest, getLangKeyName(), getLangKeyDescription());
+        T task = constructor.create(quest);
         task.updateId(quest.getTasks().size());
         quest.getTasks().add(task);
         SaveHelper.add(EditType.TASK_CREATE);
@@ -90,6 +90,6 @@ public final class TaskType<T extends QuestTask<?>> {
     }
     
     public interface TaskConstructor<T extends QuestTask<?>> {
-        T create(Quest quest, String name, String description);
+        T create(Quest quest);
     }
 }

--- a/common/src/main/java/hardcorequesting/common/quests/task/TaskType.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/TaskType.java
@@ -1,5 +1,6 @@
 package hardcorequesting.common.quests.task;
 
+import com.google.common.collect.ImmutableMap;
 import hardcorequesting.common.quests.Quest;
 import hardcorequesting.common.quests.task.icon.GetAdvancementTask;
 import hardcorequesting.common.quests.task.icon.KillMobsTask;
@@ -13,41 +14,68 @@ import hardcorequesting.common.util.SaveHelper;
 import hardcorequesting.common.util.Translator;
 import net.minecraft.network.chat.FormattedText;
 
-public enum TaskType {
-    CONSUME(ConsumeItemTask.class, "consume", ConsumeItemTask::new),
-    CRAFT(CraftingTask.class, "craft", CraftingTask::new),
-    LOCATION(VisitLocationTask.class, "location", VisitLocationTask::new),
-    CONSUME_QDS(ConsumeItemQDSTask.class, "consumeQDS", ConsumeItemQDSTask::new),
-    DETECT(DetectItemTask.class, "detect", DetectItemTask::new),
-    KILL(KillMobsTask.class, "kill", KillMobsTask::new),
-    TAME(TameMobsTask.class, "tame", TameMobsTask::new),
-    DEATH(DeathTask.class, "death", DeathTask::new),
-    REPUTATION(HaveReputationTask.class, "reputation", HaveReputationTask::new),
-    REPUTATION_KILL(KillReputationTask.class, "reputationKill", KillReputationTask::new),
-    ADVANCEMENT(GetAdvancementTask.class, "advancement", GetAdvancementTask::new),
-    COMPLETION(CompleteQuestTask.class, "completion", CompleteQuestTask::new),
-    BLOCK_BREAK(BreakBlockTask.class, "break", BreakBlockTask::new),
-    BLOCK_PLACE(PlaceBlockTask.class, "place", PlaceBlockTask::new);
+import java.util.Collection;
+import java.util.Map;
+
+public final class TaskType<T extends QuestTask<?>> {
+    public static final TaskType<ConsumeItemTask> CONSUME = new TaskType<>(ConsumeItemTask.class, "consume", ConsumeItemTask::new);
+    public static final TaskType<CraftingTask> CRAFT = new TaskType<>(CraftingTask.class, "craft", CraftingTask::new);
+    public static final TaskType<VisitLocationTask> LOCATION = new TaskType<>(VisitLocationTask.class, "location", VisitLocationTask::new);
+    public static final TaskType<ConsumeItemQDSTask> CONSUME_QDS = new TaskType<>(ConsumeItemQDSTask.class, "consumeQDS", ConsumeItemQDSTask::new);
+    public static final TaskType<DetectItemTask> DETECT = new TaskType<>(DetectItemTask.class, "detect", DetectItemTask::new);
+    public static final TaskType<KillMobsTask> KILL = new TaskType<>(KillMobsTask.class, "kill", KillMobsTask::new);
+    public static final TaskType<TameMobsTask> TAME = new TaskType<>(TameMobsTask.class, "tame", TameMobsTask::new);
+    public static final TaskType<DeathTask> DEATH = new TaskType<>(DeathTask.class, "death", DeathTask::new);
+    public static final TaskType<HaveReputationTask> REPUTATION = new TaskType<>(HaveReputationTask.class, "reputation", HaveReputationTask::new);
+    public static final TaskType<KillReputationTask> REPUTATION_KILL = new TaskType<>(KillReputationTask.class, "reputationKill", KillReputationTask::new);
+    public static final TaskType<GetAdvancementTask> ADVANCEMENT = new TaskType<>(GetAdvancementTask.class, "advancement", GetAdvancementTask::new);
+    public static final TaskType<CompleteQuestTask> COMPLETION = new TaskType<>(CompleteQuestTask.class, "completion", CompleteQuestTask::new);
+    public static final TaskType<BreakBlockTask> BLOCK_BREAK = new TaskType<>(BreakBlockTask.class, "break", BreakBlockTask::new);
+    public static final TaskType<PlaceBlockTask> BLOCK_PLACE = new TaskType<>(PlaceBlockTask.class, "place", PlaceBlockTask::new);
     
-    private final Class<? extends QuestTask<?>> clazz;
+    private static final Map<String, TaskType<?>> TYPES = ImmutableMap.<String, TaskType<?>>builder().put("consume", CONSUME).put("craft", CRAFT)
+            .put("location", LOCATION).put("consume_qds", CONSUME_QDS).put("detect", DETECT).put("kill", KILL).put("tame", TAME).put("death", DEATH)
+            .put("reputation", REPUTATION).put("reputation_kill", REPUTATION_KILL).put("advancement", ADVANCEMENT).put("completion", COMPLETION)
+            .put("block_break", BLOCK_BREAK).put("block_place", BLOCK_PLACE).build();
+    
+    private final Class<T> clazz;
     private final String id;
-    private final TaskConstructor<?> constructor;
+    private final TaskConstructor<T> constructor;
     
-    <T extends QuestTask<?>> TaskType(Class<T> clazz, String id, TaskConstructor<T> constructor) {
+    private TaskType(Class<T> clazz, String id, TaskConstructor<T> constructor) {
         this.clazz = clazz;
         this.id = id;
         this.constructor = constructor;
     }
     
-    public static TaskType getType(Class<?> clazz) {
-        for (TaskType type : TaskType.values()) {
-            if (type.clazz == clazz) return type;
-        }
-        return CONSUME;
+    public static Collection<TaskType<?>> values() {
+        return TYPES.values();
     }
     
-    public QuestTask<?> addTask(Quest quest) {
-        QuestTask<?> task = constructor.create(quest, getLangKeyName(), getLangKeyDescription());
+    public static TaskType<?> getType(Class<?> clazz) {
+        for (TaskType<?> type : values()) {
+            if (type.clazz == clazz) return type;
+        }
+        throw new IllegalArgumentException(clazz.getName() + " does not have a valid task type");
+    }
+    
+    public String toDataName() {
+        for (Map.Entry<String, TaskType<?>> entry : TYPES.entrySet()) {
+            if (entry.getValue() == this)
+                return entry.getKey();
+        }
+        throw new IllegalStateException(id + " is not registered as a task type");
+    }
+    
+    public static TaskType<?> fromDataName(String str) {
+        TaskType<?> type = TYPES.get(str);
+        if (type != null)
+            return type;
+        else throw new IllegalArgumentException(str + "is not a valid task type name");
+    }
+    
+    public T addTask(Quest quest) {
+        T task = constructor.create(quest, getLangKeyName(), getLangKeyDescription());
         task.updateId(quest.getTasks().size());
         quest.getTasks().add(task);
         SaveHelper.add(EditType.TASK_CREATE);

--- a/common/src/main/java/hardcorequesting/common/quests/task/icon/GetAdvancementTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/icon/GetAdvancementTask.java
@@ -10,6 +10,7 @@ import hardcorequesting.common.io.adapter.Adapter;
 import hardcorequesting.common.io.adapter.QuestTaskAdapter;
 import hardcorequesting.common.quests.Quest;
 import hardcorequesting.common.quests.data.AdvancementTaskData;
+import hardcorequesting.common.quests.task.TaskType;
 import hardcorequesting.common.team.Team;
 import hardcorequesting.common.util.EditType;
 import net.fabricmc.api.EnvType;
@@ -33,7 +34,7 @@ public class GetAdvancementTask extends IconLayoutTask<GetAdvancementTask.Part, 
     private static final String ADVANCEMENTS = "advancements";
     
     public GetAdvancementTask(Quest parent, String description, String longDescription) {
-        super(AdvancementTaskData.class, EditType.Type.ADVANCEMENT, parent, description, longDescription);
+        super(TaskType.ADVANCEMENT, AdvancementTaskData.class, EditType.Type.ADVANCEMENT, parent, description, longDescription);
         
         register(EventTrigger.Type.ADVANCEMENT, EventTrigger.Type.OPEN_BOOK);
     }

--- a/common/src/main/java/hardcorequesting/common/quests/task/icon/GetAdvancementTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/icon/GetAdvancementTask.java
@@ -33,8 +33,8 @@ import java.util.UUID;
 public class GetAdvancementTask extends IconLayoutTask<GetAdvancementTask.Part, AdvancementTaskData> {
     private static final String ADVANCEMENTS = "advancements";
     
-    public GetAdvancementTask(Quest parent, String description, String longDescription) {
-        super(TaskType.ADVANCEMENT, AdvancementTaskData.class, EditType.Type.ADVANCEMENT, parent, description, longDescription);
+    public GetAdvancementTask(Quest parent) {
+        super(TaskType.ADVANCEMENT, AdvancementTaskData.class, EditType.Type.ADVANCEMENT, parent);
         
         register(EventTrigger.Type.ADVANCEMENT, EventTrigger.Type.OPEN_BOOK);
     }

--- a/common/src/main/java/hardcorequesting/common/quests/task/icon/GetAdvancementTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/icon/GetAdvancementTask.java
@@ -2,9 +2,6 @@ package hardcorequesting.common.quests.task.icon;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
-import hardcorequesting.common.client.interfaces.GuiQuestBook;
-import hardcorequesting.common.client.interfaces.graphic.task.AdvancementTaskGraphic;
-import hardcorequesting.common.client.interfaces.graphic.task.TaskGraphic;
 import hardcorequesting.common.event.EventTrigger;
 import hardcorequesting.common.io.adapter.Adapter;
 import hardcorequesting.common.io.adapter.QuestTaskAdapter;
@@ -13,8 +10,6 @@ import hardcorequesting.common.quests.data.AdvancementTaskData;
 import hardcorequesting.common.quests.task.TaskType;
 import hardcorequesting.common.team.Team;
 import hardcorequesting.common.util.EditType;
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.minecraft.advancements.Advancement;
 import net.minecraft.advancements.AdvancementProgress;
 import net.minecraft.resources.ResourceLocation;
@@ -37,12 +32,6 @@ public class GetAdvancementTask extends IconLayoutTask<GetAdvancementTask.Part, 
         super(TaskType.ADVANCEMENT, AdvancementTaskData.class, EditType.Type.ADVANCEMENT, parent);
         
         register(EventTrigger.Type.ADVANCEMENT, EventTrigger.Type.OPEN_BOOK);
-    }
-    
-    @Environment(EnvType.CLIENT)
-    @Override
-    public TaskGraphic createGraphic(UUID playerId, GuiQuestBook gui) {
-        return new AdvancementTaskGraphic(this, parts, playerId, gui);
     }
     
     @Override

--- a/common/src/main/java/hardcorequesting/common/quests/task/icon/IconLayoutTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/icon/IconLayoutTask.java
@@ -6,6 +6,7 @@ import hardcorequesting.common.quests.Quest;
 import hardcorequesting.common.quests.data.TaskData;
 import hardcorequesting.common.quests.task.PartList;
 import hardcorequesting.common.quests.task.QuestTask;
+import hardcorequesting.common.quests.task.TaskType;
 import hardcorequesting.common.util.EditType;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
@@ -20,9 +21,10 @@ public abstract class IconLayoutTask<T extends IconLayoutTask.Part, Data extends
     
     protected final PartList<T> parts;
     
-    public IconLayoutTask(Class<Data> dataType, EditType.Type type, Quest parent, String description, String longDescription) {
-        super(dataType, parent, description, longDescription);
-        parts = new PartList<>(this::createEmpty, type, LIMIT);
+    public IconLayoutTask(TaskType<? extends IconLayoutTask<T, Data>> type, Class<Data> dataType, EditType.Type editType,
+                          Quest parent, String description, String longDescription) {
+        super(type, dataType, parent, description, longDescription);
+        parts = new PartList<>(this::createEmpty, editType, LIMIT);
     }
     
     

--- a/common/src/main/java/hardcorequesting/common/quests/task/icon/IconLayoutTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/icon/IconLayoutTask.java
@@ -27,6 +27,9 @@ public abstract class IconLayoutTask<T extends IconLayoutTask.Part, Data extends
         parts = new PartList<>(this::createEmpty, editType, LIMIT);
     }
     
+    public PartList<T> getParts() {
+        return parts;
+    }
     
     protected abstract T createEmpty();
     

--- a/common/src/main/java/hardcorequesting/common/quests/task/icon/IconLayoutTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/icon/IconLayoutTask.java
@@ -22,8 +22,8 @@ public abstract class IconLayoutTask<T extends IconLayoutTask.Part, Data extends
     protected final PartList<T> parts;
     
     public IconLayoutTask(TaskType<? extends IconLayoutTask<T, Data>> type, Class<Data> dataType, EditType.Type editType,
-                          Quest parent, String description, String longDescription) {
-        super(type, dataType, parent, description, longDescription);
+                          Quest parent) {
+        super(type, dataType, parent);
         parts = new PartList<>(this::createEmpty, editType, LIMIT);
     }
     

--- a/common/src/main/java/hardcorequesting/common/quests/task/icon/KillMobsTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/icon/KillMobsTask.java
@@ -32,8 +32,8 @@ import java.util.UUID;
 public class KillMobsTask extends IconLayoutTask<KillMobsTask.Part, MobTaskData> {
     private static final String MOBS = "mobs";
     
-    public KillMobsTask(Quest parent, String description, String longDescription) {
-        super(TaskType.KILL, MobTaskData.class, EditType.Type.MONSTER, parent, description, longDescription);
+    public KillMobsTask(Quest parent) {
+        super(TaskType.KILL, MobTaskData.class, EditType.Type.MONSTER, parent);
         register(EventTrigger.Type.DEATH);
     }
     

--- a/common/src/main/java/hardcorequesting/common/quests/task/icon/KillMobsTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/icon/KillMobsTask.java
@@ -10,6 +10,7 @@ import hardcorequesting.common.io.adapter.Adapter;
 import hardcorequesting.common.io.adapter.QuestTaskAdapter;
 import hardcorequesting.common.quests.Quest;
 import hardcorequesting.common.quests.data.MobTaskData;
+import hardcorequesting.common.quests.task.TaskType;
 import hardcorequesting.common.team.Team;
 import hardcorequesting.common.util.EditType;
 import net.fabricmc.api.EnvType;
@@ -32,7 +33,7 @@ public class KillMobsTask extends IconLayoutTask<KillMobsTask.Part, MobTaskData>
     private static final String MOBS = "mobs";
     
     public KillMobsTask(Quest parent, String description, String longDescription) {
-        super(MobTaskData.class, EditType.Type.MONSTER, parent, description, longDescription);
+        super(TaskType.KILL, MobTaskData.class, EditType.Type.MONSTER, parent, description, longDescription);
         register(EventTrigger.Type.DEATH);
     }
     

--- a/common/src/main/java/hardcorequesting/common/quests/task/icon/KillMobsTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/icon/KillMobsTask.java
@@ -2,9 +2,6 @@ package hardcorequesting.common.quests.task.icon;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
-import hardcorequesting.common.client.interfaces.GuiQuestBook;
-import hardcorequesting.common.client.interfaces.graphic.task.KillMobsTaskGraphic;
-import hardcorequesting.common.client.interfaces.graphic.task.TaskGraphic;
 import hardcorequesting.common.event.EventTrigger;
 import hardcorequesting.common.io.adapter.Adapter;
 import hardcorequesting.common.io.adapter.QuestTaskAdapter;
@@ -13,8 +10,6 @@ import hardcorequesting.common.quests.data.MobTaskData;
 import hardcorequesting.common.quests.task.TaskType;
 import hardcorequesting.common.team.Team;
 import hardcorequesting.common.util.EditType;
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.GsonHelper;
@@ -35,12 +30,6 @@ public class KillMobsTask extends IconLayoutTask<KillMobsTask.Part, MobTaskData>
     public KillMobsTask(Quest parent) {
         super(TaskType.KILL, MobTaskData.class, EditType.Type.MONSTER, parent);
         register(EventTrigger.Type.DEATH);
-    }
-    
-    @Environment(EnvType.CLIENT)
-    @Override
-    public TaskGraphic createGraphic(UUID playerId, GuiQuestBook gui) {
-        return new KillMobsTaskGraphic(this, parts, playerId, gui);
     }
     
     @Override

--- a/common/src/main/java/hardcorequesting/common/quests/task/icon/TameMobsTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/icon/TameMobsTask.java
@@ -3,9 +3,6 @@ package hardcorequesting.common.quests.task.icon;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.mojang.datafixers.util.Either;
-import hardcorequesting.common.client.interfaces.GuiQuestBook;
-import hardcorequesting.common.client.interfaces.graphic.task.TameMobsTaskGraphic;
-import hardcorequesting.common.client.interfaces.graphic.task.TaskGraphic;
 import hardcorequesting.common.event.EventTrigger;
 import hardcorequesting.common.io.adapter.Adapter;
 import hardcorequesting.common.io.adapter.QuestTaskAdapter;
@@ -40,12 +37,6 @@ public class TameMobsTask extends IconLayoutTask<TameMobsTask.Part, TameTaskData
     public TameMobsTask(Quest parent) {
         super(TaskType.TAME, TameTaskData.class, EditType.Type.MONSTER, parent);
         register(EventTrigger.Type.ANIMAL_TAME);
-    }
-    
-    @Environment(EnvType.CLIENT)
-    @Override
-    public TaskGraphic createGraphic(UUID playerId, GuiQuestBook gui) {
-        return new TameMobsTaskGraphic(this, parts, playerId, gui);
     }
     
     @Override

--- a/common/src/main/java/hardcorequesting/common/quests/task/icon/TameMobsTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/icon/TameMobsTask.java
@@ -37,8 +37,8 @@ public class TameMobsTask extends IconLayoutTask<TameMobsTask.Part, TameTaskData
     
     public static final ResourceLocation ABSTRACT_HORSE = new ResourceLocation("abstracthorse");
     
-    public TameMobsTask(Quest parent, String description, String longDescription) {
-        super(TaskType.TAME, TameTaskData.class, EditType.Type.MONSTER, parent, description, longDescription);
+    public TameMobsTask(Quest parent) {
+        super(TaskType.TAME, TameTaskData.class, EditType.Type.MONSTER, parent);
         register(EventTrigger.Type.ANIMAL_TAME);
     }
     

--- a/common/src/main/java/hardcorequesting/common/quests/task/icon/TameMobsTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/icon/TameMobsTask.java
@@ -11,6 +11,7 @@ import hardcorequesting.common.io.adapter.Adapter;
 import hardcorequesting.common.io.adapter.QuestTaskAdapter;
 import hardcorequesting.common.quests.Quest;
 import hardcorequesting.common.quests.data.TameTaskData;
+import hardcorequesting.common.quests.task.TaskType;
 import hardcorequesting.common.team.Team;
 import hardcorequesting.common.util.EditType;
 import net.fabricmc.api.EnvType;
@@ -37,7 +38,7 @@ public class TameMobsTask extends IconLayoutTask<TameMobsTask.Part, TameTaskData
     public static final ResourceLocation ABSTRACT_HORSE = new ResourceLocation("abstracthorse");
     
     public TameMobsTask(Quest parent, String description, String longDescription) {
-        super(TameTaskData.class, EditType.Type.MONSTER, parent, description, longDescription);
+        super(TaskType.TAME, TameTaskData.class, EditType.Type.MONSTER, parent, description, longDescription);
         register(EventTrigger.Type.ANIMAL_TAME);
     }
     

--- a/common/src/main/java/hardcorequesting/common/quests/task/icon/VisitLocationTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/icon/VisitLocationTask.java
@@ -10,6 +10,7 @@ import hardcorequesting.common.io.adapter.Adapter;
 import hardcorequesting.common.io.adapter.QuestTaskAdapter;
 import hardcorequesting.common.quests.Quest;
 import hardcorequesting.common.quests.data.LocationTaskData;
+import hardcorequesting.common.quests.task.TaskType;
 import hardcorequesting.common.team.Team;
 import hardcorequesting.common.util.EditType;
 import hardcorequesting.common.util.Translator;
@@ -37,7 +38,7 @@ public class VisitLocationTask extends IconLayoutTask<VisitLocationTask.Part, Lo
     private int delay = 1;
     
     public VisitLocationTask(Quest parent, String description, String longDescription) {
-        super(LocationTaskData.class, EditType.Type.LOCATION, parent, description, longDescription);
+        super(TaskType.LOCATION, LocationTaskData.class, EditType.Type.LOCATION, parent, description, longDescription);
         
         register(EventTrigger.Type.SERVER, EventTrigger.Type.PLAYER);
     }

--- a/common/src/main/java/hardcorequesting/common/quests/task/icon/VisitLocationTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/icon/VisitLocationTask.java
@@ -37,8 +37,8 @@ public class VisitLocationTask extends IconLayoutTask<VisitLocationTask.Part, Lo
     private static final int CHECK_DELAY = 20;
     private int delay = 1;
     
-    public VisitLocationTask(Quest parent, String description, String longDescription) {
-        super(TaskType.LOCATION, LocationTaskData.class, EditType.Type.LOCATION, parent, description, longDescription);
+    public VisitLocationTask(Quest parent) {
+        super(TaskType.LOCATION, LocationTaskData.class, EditType.Type.LOCATION, parent);
         
         register(EventTrigger.Type.SERVER, EventTrigger.Type.PLAYER);
     }

--- a/common/src/main/java/hardcorequesting/common/quests/task/icon/VisitLocationTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/icon/VisitLocationTask.java
@@ -2,9 +2,6 @@ package hardcorequesting.common.quests.task.icon;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
-import hardcorequesting.common.client.interfaces.GuiQuestBook;
-import hardcorequesting.common.client.interfaces.graphic.task.LocationTaskGraphic;
-import hardcorequesting.common.client.interfaces.graphic.task.TaskGraphic;
 import hardcorequesting.common.event.EventTrigger;
 import hardcorequesting.common.io.adapter.Adapter;
 import hardcorequesting.common.io.adapter.QuestTaskAdapter;
@@ -14,8 +11,6 @@ import hardcorequesting.common.quests.task.TaskType;
 import hardcorequesting.common.team.Team;
 import hardcorequesting.common.util.EditType;
 import hardcorequesting.common.util.Translator;
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.FormattedText;
 import net.minecraft.server.MinecraftServer;
@@ -41,12 +36,6 @@ public class VisitLocationTask extends IconLayoutTask<VisitLocationTask.Part, Lo
         super(TaskType.LOCATION, LocationTaskData.class, EditType.Type.LOCATION, parent);
         
         register(EventTrigger.Type.SERVER, EventTrigger.Type.PLAYER);
-    }
-    
-    @Environment(EnvType.CLIENT)
-    @Override
-    public TaskGraphic createGraphic(UUID playerId, GuiQuestBook gui) {
-        return new LocationTaskGraphic(this, parts, playerId, gui);
     }
     
     @Override

--- a/common/src/main/java/hardcorequesting/common/quests/task/item/BlockRequirementTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/item/BlockRequirementTask.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonObject;
 import hardcorequesting.common.io.adapter.Adapter;
 import hardcorequesting.common.io.adapter.QuestTaskAdapter;
 import hardcorequesting.common.quests.Quest;
+import hardcorequesting.common.quests.task.TaskType;
 import net.minecraft.core.NonNullList;
 import net.minecraft.util.GsonHelper;
 import net.minecraft.world.entity.player.Player;
@@ -18,8 +19,8 @@ public abstract class BlockRequirementTask extends ItemRequirementTask {
     public static final String NULL_NAME = "item.null.name";
     private static final String BLOCKS = "blocks";
     
-    public BlockRequirementTask(Quest parent, String description, String longDescription) {
-        super(parent, description, longDescription);
+    public BlockRequirementTask(TaskType<? extends BlockRequirementTask> type, Quest parent, String description, String longDescription) {
+        super(type, parent, description, longDescription);
     }
     
     @Override

--- a/common/src/main/java/hardcorequesting/common/quests/task/item/BlockRequirementTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/item/BlockRequirementTask.java
@@ -19,8 +19,8 @@ public abstract class BlockRequirementTask extends ItemRequirementTask {
     public static final String NULL_NAME = "item.null.name";
     private static final String BLOCKS = "blocks";
     
-    public BlockRequirementTask(TaskType<? extends BlockRequirementTask> type, Quest parent, String description, String longDescription) {
-        super(type, parent, description, longDescription);
+    public BlockRequirementTask(TaskType<? extends BlockRequirementTask> type, Quest parent) {
+        super(type, parent);
     }
     
     @Override

--- a/common/src/main/java/hardcorequesting/common/quests/task/item/BreakBlockTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/item/BreakBlockTask.java
@@ -8,8 +8,8 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.block.state.BlockState;
 
 public class BreakBlockTask extends BlockRequirementTask {
-    public BreakBlockTask(Quest parent, String description, String longDescription) {
-        super(TaskType.BLOCK_BREAK, parent, description, longDescription);
+    public BreakBlockTask(Quest parent) {
+        super(TaskType.BLOCK_BREAK, parent);
         
         register(EventTrigger.Type.BLOCK_BROKEN);
     }

--- a/common/src/main/java/hardcorequesting/common/quests/task/item/BreakBlockTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/item/BreakBlockTask.java
@@ -2,13 +2,14 @@ package hardcorequesting.common.quests.task.item;
 
 import hardcorequesting.common.event.EventTrigger;
 import hardcorequesting.common.quests.Quest;
+import hardcorequesting.common.quests.task.TaskType;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.block.state.BlockState;
 
 public class BreakBlockTask extends BlockRequirementTask {
     public BreakBlockTask(Quest parent, String description, String longDescription) {
-        super(parent, description, longDescription);
+        super(TaskType.BLOCK_BREAK, parent, description, longDescription);
         
         register(EventTrigger.Type.BLOCK_BROKEN);
     }

--- a/common/src/main/java/hardcorequesting/common/quests/task/item/ConsumeItemQDSTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/item/ConsumeItemQDSTask.java
@@ -4,6 +4,7 @@ import hardcorequesting.common.client.interfaces.GuiQuestBook;
 import hardcorequesting.common.client.interfaces.graphic.task.ItemTaskGraphic;
 import hardcorequesting.common.client.interfaces.graphic.task.TaskGraphic;
 import hardcorequesting.common.quests.Quest;
+import hardcorequesting.common.quests.task.TaskType;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 
@@ -12,7 +13,7 @@ import java.util.UUID;
 public class ConsumeItemQDSTask extends ConsumeItemTask {
     
     public ConsumeItemQDSTask(Quest parent, String description, String longDescription) {
-        super(parent, description, longDescription);
+        super(TaskType.CONSUME_QDS, parent, description, longDescription);
     }
     
     @Environment(EnvType.CLIENT)

--- a/common/src/main/java/hardcorequesting/common/quests/task/item/ConsumeItemQDSTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/item/ConsumeItemQDSTask.java
@@ -12,8 +12,8 @@ import java.util.UUID;
 
 public class ConsumeItemQDSTask extends ConsumeItemTask {
     
-    public ConsumeItemQDSTask(Quest parent, String description, String longDescription) {
-        super(TaskType.CONSUME_QDS, parent, description, longDescription);
+    public ConsumeItemQDSTask(Quest parent) {
+        super(TaskType.CONSUME_QDS, parent);
     }
     
     @Environment(EnvType.CLIENT)

--- a/common/src/main/java/hardcorequesting/common/quests/task/item/ConsumeItemQDSTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/item/ConsumeItemQDSTask.java
@@ -1,24 +1,11 @@
 package hardcorequesting.common.quests.task.item;
 
-import hardcorequesting.common.client.interfaces.GuiQuestBook;
-import hardcorequesting.common.client.interfaces.graphic.task.ItemTaskGraphic;
-import hardcorequesting.common.client.interfaces.graphic.task.TaskGraphic;
 import hardcorequesting.common.quests.Quest;
 import hardcorequesting.common.quests.task.TaskType;
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
-
-import java.util.UUID;
 
 public class ConsumeItemQDSTask extends ConsumeItemTask {
     
     public ConsumeItemQDSTask(Quest parent) {
         super(TaskType.CONSUME_QDS, parent);
-    }
-    
-    @Environment(EnvType.CLIENT)
-    @Override
-    public TaskGraphic createGraphic(UUID playerId, GuiQuestBook gui) {
-        return ItemTaskGraphic.createConsumeGraphic(this, parts, playerId, gui, false);
     }
 }

--- a/common/src/main/java/hardcorequesting/common/quests/task/item/ConsumeItemTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/item/ConsumeItemTask.java
@@ -18,12 +18,12 @@ import java.util.UUID;
 
 public class ConsumeItemTask extends ItemRequirementTask {
     
-    public ConsumeItemTask(Quest parent, String description, String longDescription) {
-        this(TaskType.CONSUME, parent, description, longDescription);
+    public ConsumeItemTask(Quest parent) {
+        this(TaskType.CONSUME, parent);
     }
     
-    protected ConsumeItemTask(TaskType<? extends ConsumeItemTask> type, Quest parent, String description, String longDescription) {
-        super(type, parent, description, longDescription);
+    protected ConsumeItemTask(TaskType<? extends ConsumeItemTask> type, Quest parent) {
+        super(type, parent);
     }
     
     @Environment(EnvType.CLIENT)

--- a/common/src/main/java/hardcorequesting/common/quests/task/item/ConsumeItemTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/item/ConsumeItemTask.java
@@ -1,8 +1,5 @@
 package hardcorequesting.common.quests.task.item;
 
-import hardcorequesting.common.client.interfaces.GuiQuestBook;
-import hardcorequesting.common.client.interfaces.graphic.task.ItemTaskGraphic;
-import hardcorequesting.common.client.interfaces.graphic.task.TaskGraphic;
 import hardcorequesting.common.platform.FluidStack;
 import hardcorequesting.common.quests.Quest;
 import hardcorequesting.common.quests.data.ItemsTaskData;
@@ -24,12 +21,6 @@ public class ConsumeItemTask extends ItemRequirementTask {
     
     protected ConsumeItemTask(TaskType<? extends ConsumeItemTask> type, Quest parent) {
         super(type, parent);
-    }
-    
-    @Environment(EnvType.CLIENT)
-    @Override
-    public TaskGraphic createGraphic(UUID playerId, GuiQuestBook gui) {
-        return ItemTaskGraphic.createConsumeGraphic(this, parts, playerId, gui, true);
     }
     
     public boolean increaseFluid(FluidStack fluidVolume, UUID playerId, boolean action) {

--- a/common/src/main/java/hardcorequesting/common/quests/task/item/ConsumeItemTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/item/ConsumeItemTask.java
@@ -6,6 +6,7 @@ import hardcorequesting.common.client.interfaces.graphic.task.TaskGraphic;
 import hardcorequesting.common.platform.FluidStack;
 import hardcorequesting.common.quests.Quest;
 import hardcorequesting.common.quests.data.ItemsTaskData;
+import hardcorequesting.common.quests.task.TaskType;
 import hardcorequesting.common.util.Fraction;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
@@ -18,7 +19,11 @@ import java.util.UUID;
 public class ConsumeItemTask extends ItemRequirementTask {
     
     public ConsumeItemTask(Quest parent, String description, String longDescription) {
-        super(parent, description, longDescription);
+        this(TaskType.CONSUME, parent, description, longDescription);
+    }
+    
+    protected ConsumeItemTask(TaskType<? extends ConsumeItemTask> type, Quest parent, String description, String longDescription) {
+        super(type, parent, description, longDescription);
     }
     
     @Environment(EnvType.CLIENT)

--- a/common/src/main/java/hardcorequesting/common/quests/task/item/CraftingTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/item/CraftingTask.java
@@ -2,6 +2,7 @@ package hardcorequesting.common.quests.task.item;
 
 import hardcorequesting.common.event.EventTrigger;
 import hardcorequesting.common.quests.Quest;
+import hardcorequesting.common.quests.task.TaskType;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.core.NonNullList;
@@ -11,7 +12,7 @@ import net.minecraft.world.item.ItemStack;
 public class CraftingTask extends ItemRequirementTask {
     
     public CraftingTask(Quest parent, String description, String longDescription) {
-        super(parent, description, longDescription);
+        super(TaskType.CRAFT, parent, description, longDescription);
         register(EventTrigger.Type.CRAFTING);
     }
     

--- a/common/src/main/java/hardcorequesting/common/quests/task/item/CraftingTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/item/CraftingTask.java
@@ -11,8 +11,8 @@ import net.minecraft.world.item.ItemStack;
 
 public class CraftingTask extends ItemRequirementTask {
     
-    public CraftingTask(Quest parent, String description, String longDescription) {
-        super(TaskType.CRAFT, parent, description, longDescription);
+    public CraftingTask(Quest parent) {
+        super(TaskType.CRAFT, parent);
         register(EventTrigger.Type.CRAFTING);
     }
     

--- a/common/src/main/java/hardcorequesting/common/quests/task/item/DetectItemTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/item/DetectItemTask.java
@@ -20,8 +20,8 @@ import java.util.UUID;
 
 public class DetectItemTask extends ItemRequirementTask {
     
-    public DetectItemTask(Quest parent, String description, String longDescription) {
-        super(TaskType.DETECT, parent, description, longDescription);
+    public DetectItemTask(Quest parent) {
+        super(TaskType.DETECT, parent);
         
         register(EventTrigger.Type.CRAFTING, EventTrigger.Type.PICK_UP, EventTrigger.Type.OPEN_BOOK);
     }

--- a/common/src/main/java/hardcorequesting/common/quests/task/item/DetectItemTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/item/DetectItemTask.java
@@ -8,6 +8,7 @@ import hardcorequesting.common.event.EventTrigger;
 import hardcorequesting.common.platform.FluidStack;
 import hardcorequesting.common.quests.Quest;
 import hardcorequesting.common.quests.data.ItemsTaskData;
+import hardcorequesting.common.quests.task.TaskType;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.core.NonNullList;
@@ -20,7 +21,7 @@ import java.util.UUID;
 public class DetectItemTask extends ItemRequirementTask {
     
     public DetectItemTask(Quest parent, String description, String longDescription) {
-        super(parent, description, longDescription);
+        super(TaskType.DETECT, parent, description, longDescription);
         
         register(EventTrigger.Type.CRAFTING, EventTrigger.Type.PICK_UP, EventTrigger.Type.OPEN_BOOK);
     }

--- a/common/src/main/java/hardcorequesting/common/quests/task/item/DetectItemTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/item/DetectItemTask.java
@@ -1,9 +1,6 @@
 package hardcorequesting.common.quests.task.item;
 
 import hardcorequesting.common.HardcoreQuestingCore;
-import hardcorequesting.common.client.interfaces.GuiQuestBook;
-import hardcorequesting.common.client.interfaces.graphic.task.ItemTaskGraphic;
-import hardcorequesting.common.client.interfaces.graphic.task.TaskGraphic;
 import hardcorequesting.common.event.EventTrigger;
 import hardcorequesting.common.platform.FluidStack;
 import hardcorequesting.common.quests.Quest;
@@ -24,12 +21,6 @@ public class DetectItemTask extends ItemRequirementTask {
         super(TaskType.DETECT, parent);
         
         register(EventTrigger.Type.CRAFTING, EventTrigger.Type.PICK_UP, EventTrigger.Type.OPEN_BOOK);
-    }
-    
-    @Environment(EnvType.CLIENT)
-    @Override
-    public TaskGraphic createGraphic(UUID playerId, GuiQuestBook gui) {
-        return ItemTaskGraphic.createDetectGraphic(this, parts, playerId, gui);
     }
     
     @Environment(EnvType.CLIENT)

--- a/common/src/main/java/hardcorequesting/common/quests/task/item/ItemRequirementTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/item/ItemRequirementTask.java
@@ -15,6 +15,7 @@ import hardcorequesting.common.quests.QuestingDataManager;
 import hardcorequesting.common.quests.data.ItemsTaskData;
 import hardcorequesting.common.quests.task.PartList;
 import hardcorequesting.common.quests.task.QuestTask;
+import hardcorequesting.common.quests.task.TaskType;
 import hardcorequesting.common.team.Team;
 import hardcorequesting.common.util.EditType;
 import net.fabricmc.api.EnvType;
@@ -34,8 +35,8 @@ public abstract class ItemRequirementTask extends QuestTask<ItemsTaskData> {
     
     protected final PartList<Part> parts = new PartList<>(Part::new, EditType.Type.TASK_ITEM, LIMIT);
     
-    public ItemRequirementTask(Quest parent, String description, String longDescription) {
-        super(ItemsTaskData.class, parent, description, longDescription);
+    public ItemRequirementTask(TaskType<? extends ItemRequirementTask> type, Quest parent, String description, String longDescription) {
+        super(type, ItemsTaskData.class, parent, description, longDescription);
     }
     
     @Environment(EnvType.CLIENT)

--- a/common/src/main/java/hardcorequesting/common/quests/task/item/ItemRequirementTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/item/ItemRequirementTask.java
@@ -35,8 +35,8 @@ public abstract class ItemRequirementTask extends QuestTask<ItemsTaskData> {
     
     protected final PartList<Part> parts = new PartList<>(Part::new, EditType.Type.TASK_ITEM, LIMIT);
     
-    public ItemRequirementTask(TaskType<? extends ItemRequirementTask> type, Quest parent, String description, String longDescription) {
-        super(type, ItemsTaskData.class, parent, description, longDescription);
+    public ItemRequirementTask(TaskType<? extends ItemRequirementTask> type, Quest parent) {
+        super(type, ItemsTaskData.class, parent);
     }
     
     @Environment(EnvType.CLIENT)

--- a/common/src/main/java/hardcorequesting/common/quests/task/item/ItemRequirementTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/item/ItemRequirementTask.java
@@ -3,9 +3,6 @@ package hardcorequesting.common.quests.task.item;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.mojang.datafixers.util.Either;
-import hardcorequesting.common.client.interfaces.GuiQuestBook;
-import hardcorequesting.common.client.interfaces.graphic.task.ItemTaskGraphic;
-import hardcorequesting.common.client.interfaces.graphic.task.TaskGraphic;
 import hardcorequesting.common.io.adapter.Adapter;
 import hardcorequesting.common.io.adapter.QuestTaskAdapter;
 import hardcorequesting.common.platform.FluidStack;
@@ -39,10 +36,8 @@ public abstract class ItemRequirementTask extends QuestTask<ItemsTaskData> {
         super(type, ItemsTaskData.class, parent);
     }
     
-    @Environment(EnvType.CLIENT)
-    @Override
-    public TaskGraphic createGraphic(UUID playerId, GuiQuestBook gui) {
-        return new ItemTaskGraphic(this, parts, playerId, gui);
+    public PartList<Part> getParts() {
+        return parts;
     }
     
     @Override

--- a/common/src/main/java/hardcorequesting/common/quests/task/item/PlaceBlockTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/item/PlaceBlockTask.java
@@ -2,6 +2,7 @@ package hardcorequesting.common.quests.task.item;
 
 import hardcorequesting.common.event.EventTrigger;
 import hardcorequesting.common.quests.Quest;
+import hardcorequesting.common.quests.task.TaskType;
 import net.minecraft.core.NonNullList;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Player;
@@ -10,7 +11,7 @@ import net.minecraft.world.level.Level;
 
 public class PlaceBlockTask extends ItemRequirementTask {
     public PlaceBlockTask(Quest parent, String description, String longDescription) {
-        super(parent, description, longDescription);
+        super(TaskType.BLOCK_PLACE, parent, description, longDescription);
         
         register(EventTrigger.Type.ITEM_USED);
     }

--- a/common/src/main/java/hardcorequesting/common/quests/task/item/PlaceBlockTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/item/PlaceBlockTask.java
@@ -10,8 +10,8 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 
 public class PlaceBlockTask extends ItemRequirementTask {
-    public PlaceBlockTask(Quest parent, String description, String longDescription) {
-        super(TaskType.BLOCK_PLACE, parent, description, longDescription);
+    public PlaceBlockTask(Quest parent) {
+        super(TaskType.BLOCK_PLACE, parent);
         
         register(EventTrigger.Type.ITEM_USED);
     }

--- a/common/src/main/java/hardcorequesting/common/quests/task/reputation/HaveReputationTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/reputation/HaveReputationTask.java
@@ -9,8 +9,8 @@ import net.minecraft.world.entity.player.Player;
 
 public class HaveReputationTask extends ReputationTask<TaskData> {
     
-    public HaveReputationTask(Quest parent, String description, String longDescription) {
-        super(TaskType.REPUTATION, TaskData.class, parent, description, longDescription);
+    public HaveReputationTask(Quest parent) {
+        super(TaskType.REPUTATION, TaskData.class, parent);
         
         register(EventTrigger.Type.OPEN_BOOK, EventTrigger.Type.REPUTATION_CHANGE);
     }

--- a/common/src/main/java/hardcorequesting/common/quests/task/reputation/HaveReputationTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/reputation/HaveReputationTask.java
@@ -3,13 +3,14 @@ package hardcorequesting.common.quests.task.reputation;
 import hardcorequesting.common.event.EventTrigger;
 import hardcorequesting.common.quests.Quest;
 import hardcorequesting.common.quests.data.TaskData;
+import hardcorequesting.common.quests.task.TaskType;
 import hardcorequesting.common.team.Team;
 import net.minecraft.world.entity.player.Player;
 
 public class HaveReputationTask extends ReputationTask<TaskData> {
     
     public HaveReputationTask(Quest parent, String description, String longDescription) {
-        super(TaskData.class, parent, description, longDescription);
+        super(TaskType.REPUTATION, TaskData.class, parent, description, longDescription);
         
         register(EventTrigger.Type.OPEN_BOOK, EventTrigger.Type.REPUTATION_CHANGE);
     }

--- a/common/src/main/java/hardcorequesting/common/quests/task/reputation/KillReputationTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/reputation/KillReputationTask.java
@@ -26,8 +26,8 @@ public class KillReputationTask extends ReputationTask<ReputationKillTaskData> {
     private static final String KILLS = "kills";
     private int kills;
     
-    public KillReputationTask(Quest parent, String description, String longDescription) {
-        super(TaskType.REPUTATION_KILL, ReputationKillTaskData.class, parent, description, longDescription);
+    public KillReputationTask(Quest parent) {
+        super(TaskType.REPUTATION_KILL, ReputationKillTaskData.class, parent);
         
         register(EventTrigger.Type.DEATH);
     }

--- a/common/src/main/java/hardcorequesting/common/quests/task/reputation/KillReputationTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/reputation/KillReputationTask.java
@@ -8,6 +8,7 @@ import hardcorequesting.common.event.EventTrigger;
 import hardcorequesting.common.io.adapter.Adapter;
 import hardcorequesting.common.quests.Quest;
 import hardcorequesting.common.quests.data.ReputationKillTaskData;
+import hardcorequesting.common.quests.task.TaskType;
 import hardcorequesting.common.quests.task.icon.KillMobsTask;
 import hardcorequesting.common.team.Team;
 import hardcorequesting.common.util.EditType;
@@ -26,7 +27,7 @@ public class KillReputationTask extends ReputationTask<ReputationKillTaskData> {
     private int kills;
     
     public KillReputationTask(Quest parent, String description, String longDescription) {
-        super(ReputationKillTaskData.class, parent, description, longDescription);
+        super(TaskType.REPUTATION_KILL, ReputationKillTaskData.class, parent, description, longDescription);
         
         register(EventTrigger.Type.DEATH);
     }

--- a/common/src/main/java/hardcorequesting/common/quests/task/reputation/KillReputationTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/reputation/KillReputationTask.java
@@ -1,9 +1,6 @@
 package hardcorequesting.common.quests.task.reputation;
 
 import com.google.gson.JsonObject;
-import hardcorequesting.common.client.interfaces.GuiQuestBook;
-import hardcorequesting.common.client.interfaces.graphic.task.KillReputationTaskGraphic;
-import hardcorequesting.common.client.interfaces.graphic.task.TaskGraphic;
 import hardcorequesting.common.event.EventTrigger;
 import hardcorequesting.common.io.adapter.Adapter;
 import hardcorequesting.common.quests.Quest;
@@ -13,8 +10,6 @@ import hardcorequesting.common.quests.task.icon.KillMobsTask;
 import hardcorequesting.common.team.Team;
 import hardcorequesting.common.util.EditType;
 import hardcorequesting.common.util.SaveHelper;
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.minecraft.util.GsonHelper;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.LivingEntity;
@@ -30,12 +25,6 @@ public class KillReputationTask extends ReputationTask<ReputationKillTaskData> {
         super(TaskType.REPUTATION_KILL, ReputationKillTaskData.class, parent);
         
         register(EventTrigger.Type.DEATH);
-    }
-    
-    @Environment(EnvType.CLIENT)
-    @Override
-    public TaskGraphic createGraphic(UUID playerId, GuiQuestBook gui) {
-        return new KillReputationTaskGraphic(this, parts, playerId, gui);
     }
     
     @Override

--- a/common/src/main/java/hardcorequesting/common/quests/task/reputation/ReputationTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/reputation/ReputationTask.java
@@ -13,6 +13,7 @@ import hardcorequesting.common.quests.QuestingDataManager;
 import hardcorequesting.common.quests.data.TaskData;
 import hardcorequesting.common.quests.task.PartList;
 import hardcorequesting.common.quests.task.QuestTask;
+import hardcorequesting.common.quests.task.TaskType;
 import hardcorequesting.common.reputation.Reputation;
 import hardcorequesting.common.reputation.ReputationMarker;
 import hardcorequesting.common.team.Team;
@@ -34,8 +35,8 @@ public abstract class ReputationTask<Data extends TaskData> extends QuestTask<Da
     
     protected final PartList<Part> parts = new PartList<>(Part::new, EditType.Type.REPUTATION_TASK, LIMIT);
     
-    public ReputationTask(Class<Data> dataType, Quest parent, String description, String longDescription) {
-        super(dataType, parent, description, longDescription);
+    protected ReputationTask(TaskType<? extends ReputationTask<Data>> type, Class<Data> dataType, Quest parent, String description, String longDescription) {
+        super(type, dataType, parent, description, longDescription);
     }
     
     @Environment(EnvType.CLIENT)

--- a/common/src/main/java/hardcorequesting/common/quests/task/reputation/ReputationTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/reputation/ReputationTask.java
@@ -3,9 +3,6 @@ package hardcorequesting.common.quests.task.reputation;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import hardcorequesting.common.client.interfaces.GuiQuestBook;
-import hardcorequesting.common.client.interfaces.graphic.task.ReputationTaskGraphic;
-import hardcorequesting.common.client.interfaces.graphic.task.TaskGraphic;
 import hardcorequesting.common.io.adapter.Adapter;
 import hardcorequesting.common.io.adapter.QuestTaskAdapter;
 import hardcorequesting.common.quests.Quest;
@@ -18,8 +15,6 @@ import hardcorequesting.common.reputation.Reputation;
 import hardcorequesting.common.reputation.ReputationMarker;
 import hardcorequesting.common.team.Team;
 import hardcorequesting.common.util.EditType;
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.minecraft.util.GsonHelper;
 import net.minecraft.world.entity.player.Player;
 
@@ -39,10 +34,8 @@ public abstract class ReputationTask<Data extends TaskData> extends QuestTask<Da
         super(type, dataType, parent);
     }
     
-    @Environment(EnvType.CLIENT)
-    @Override
-    public TaskGraphic createGraphic(UUID playerId, GuiQuestBook gui) {
-        return new ReputationTaskGraphic(this, parts, playerId, gui);
+    public PartList<Part> getParts() {
+        return parts;
     }
     
     @Deprecated

--- a/common/src/main/java/hardcorequesting/common/quests/task/reputation/ReputationTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/reputation/ReputationTask.java
@@ -35,8 +35,8 @@ public abstract class ReputationTask<Data extends TaskData> extends QuestTask<Da
     
     protected final PartList<Part> parts = new PartList<>(Part::new, EditType.Type.REPUTATION_TASK, LIMIT);
     
-    protected ReputationTask(TaskType<? extends ReputationTask<Data>> type, Class<Data> dataType, Quest parent, String description, String longDescription) {
-        super(type, dataType, parent, description, longDescription);
+    protected ReputationTask(TaskType<? extends ReputationTask<Data>> type, Class<Data> dataType, Quest parent) {
+        super(type, dataType, parent);
     }
     
     @Environment(EnvType.CLIENT)


### PR DESCRIPTION
Some tweaks regarding quest tasks.
Primary change was to separate remaining client components from quest task classes, by linking quest tasks to graphics through a client-side map.
For extra type safety, `TaskType` was changed to a generic similarly to how `EntityType<?>` in vanilla works. The changes to `TaskType` would also be one step closer to a quest task registry.