### PR TITLE
Update item stack, compound tag, fluid stack and fraction serialization

### DIFF
--- a/common/src/main/java/hardcorequesting/common/io/adapter/MinecraftAdapter.java
+++ b/common/src/main/java/hardcorequesting/common/io/adapter/MinecraftAdapter.java
@@ -12,7 +12,6 @@ import hardcorequesting.common.platform.FluidStack;
 import hardcorequesting.common.util.Fraction;
 import net.minecraft.core.Registry;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.NbtOps;
 import net.minecraft.nbt.TagParser;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.GsonHelper;
@@ -92,7 +91,7 @@ public class MinecraftAdapter {
         public JsonElement serialize(FluidStack src) {
             return object()
                     .add(FLUID, Registry.FLUID.getKey(src.getFluid()).toString())
-                    .add(VOLUME, Dynamic.convert(NbtOps.INSTANCE, JsonOps.INSTANCE, src.getAmount().toNbt()))
+                    .add(VOLUME, Fraction.CODEC.encodeStart(JsonOps.INSTANCE, src.getAmount()).result().orElseThrow())
                     .build();
         }
         
@@ -101,7 +100,7 @@ public class MinecraftAdapter {
             JsonObject object = json.getAsJsonObject();
             
             Fluid fluid = Registry.FLUID.get(new ResourceLocation(GsonHelper.getAsString(object, FLUID)));
-            Fraction amount = Fraction.fromNbt((CompoundTag) Dynamic.convert(JsonOps.INSTANCE, NbtOps.INSTANCE, object.get(VOLUME)));
+            Fraction amount = Fraction.CODEC.parse(JsonOps.INSTANCE, object.get(VOLUME)).result().orElseThrow();
             return HardcoreQuestingCore.platform.createFluidStack(fluid, amount);
         }
     };

--- a/common/src/main/java/hardcorequesting/common/io/adapter/MinecraftAdapter.java
+++ b/common/src/main/java/hardcorequesting/common/io/adapter/MinecraftAdapter.java
@@ -2,6 +2,9 @@ package hardcorequesting.common.io.adapter;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSyntaxException;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.serialization.Dynamic;
 import com.mojang.serialization.JsonOps;
 import hardcorequesting.common.HardcoreQuestingCore;
@@ -10,10 +13,14 @@ import hardcorequesting.common.util.Fraction;
 import net.minecraft.core.Registry;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtOps;
+import net.minecraft.nbt.TagParser;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.GsonHelper;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.material.Fluid;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Created by lang2 on 10/12/2015.
@@ -26,14 +33,35 @@ public class MinecraftAdapter {
             if (src.isEmpty())
                 return nullVal();
             
-            return Dynamic.convert(NbtOps.INSTANCE, JsonOps.INSTANCE, src.save(new CompoundTag()));
+            JsonObject jsonObj = new JsonObject();
+            jsonObj.addProperty("id", Registry.ITEM.getKey(src.getItem()).toString());
+            jsonObj.addProperty("Count", src.getCount());
+            
+            CompoundTag tag = src.getTag();
+            if (tag != null) {
+                jsonObj.add("tag", COMPOUND_TAG.serialize(tag));
+            }
+            
+            return jsonObj;
         }
         
         @Override
+        @NotNull
         public ItemStack deserialize(JsonElement json) {
             if (json.isJsonNull())
                 return ItemStack.EMPTY;
-            return ItemStack.of((CompoundTag) Dynamic.convert(JsonOps.INSTANCE, PatchedNbtOps.INSTANCE, json));
+            else {
+                JsonObject jsonObj = json.getAsJsonObject();
+                Item item = Registry.ITEM.get(new ResourceLocation(GsonHelper.getAsString(jsonObj, "id")));
+                int count = GsonHelper.getAsByte(jsonObj, "Count");
+                ItemStack stack = new ItemStack(item, count);
+                
+                if (jsonObj.has("tag")) {
+                    stack.setTag(COMPOUND_TAG.deserialize(jsonObj.get("tag")));
+                }
+                
+                return stack;
+            }
         }
     };
     // A more restrictive version of ITEM_STACK that caps stack sizes at 1
@@ -56,7 +84,7 @@ public class MinecraftAdapter {
             return stack;
         }
     };
-    public static final Adapter<FluidStack> FLUID = new Adapter<FluidStack>() {
+    public static final Adapter<FluidStack> FLUID = new Adapter<>() {
         private static final String FLUID = "fluid";
         private static final String VOLUME = "volume";
         
@@ -75,6 +103,29 @@ public class MinecraftAdapter {
             Fluid fluid = Registry.FLUID.get(new ResourceLocation(GsonHelper.getAsString(object, FLUID)));
             Fraction amount = Fraction.fromNbt((CompoundTag) Dynamic.convert(JsonOps.INSTANCE, NbtOps.INSTANCE, object.get(VOLUME)));
             return HardcoreQuestingCore.platform.createFluidStack(fluid, amount);
+        }
+    };
+    
+    // Converting a json element to a nbt tag using dynamic ops is unsafe because json does not cover the type system that nbt has.
+    // Use this adapter as a safer alternative. It stores the entire tag as a json string, ensuring that nbt types are kept.
+    // Imitates the serialization method used by SetNbtFunction.
+    public static final Adapter<CompoundTag> COMPOUND_TAG =  new Adapter<>() {
+        @Override
+        public JsonElement serialize(CompoundTag src) {
+            return new JsonPrimitive(src.toString());
+        }
+    
+        @Override
+        public @Nullable CompoundTag deserialize(JsonElement json) {
+            if (json.isJsonObject()) {   //Backwards-compatibility with HQM-1.18.2-5.10.0 and earlier
+                return (CompoundTag) Dynamic.convert(JsonOps.INSTANCE, PatchedNbtOps.INSTANCE, json);
+            } else {
+                try {
+                    return TagParser.parseTag(GsonHelper.convertToString(json, "tag"));
+                } catch (CommandSyntaxException e) {
+                    throw new JsonSyntaxException(e.getMessage());
+                }
+            }
         }
     };
 }

--- a/common/src/main/java/hardcorequesting/common/util/Fraction.java
+++ b/common/src/main/java/hardcorequesting/common/util/Fraction.java
@@ -1,14 +1,23 @@
 package hardcorequesting.common.util;
 
 import com.google.common.math.LongMath;
-import net.minecraft.nbt.CompoundTag;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
 import org.jetbrains.annotations.NotNull;
 
 import java.text.DecimalFormat;
 
+@SuppressWarnings("unused")
 public final class Fraction extends Number implements Comparable<Fraction> {
     private static final Fraction EMPTY = ofWhole(0);
     private static final DecimalFormat DECIMAL_FORMAT = new DecimalFormat("###.###");
+    
+    public static final Codec<Fraction> CODEC = RecordCodecBuilder.create(instance ->
+            instance.group(
+                    Codec.LONG.fieldOf("n").forGetter(Fraction::getNumerator),
+                    Codec.LONG.fieldOf("d").forGetter(Fraction::getDenominator)
+            ).apply(instance, Fraction::of));
+    
     private final long numerator;
     private final long denominator;
     private final boolean integer;
@@ -160,19 +169,5 @@ public final class Fraction extends Number implements Comparable<Fraction> {
     public String toString() {
         if (integer) return toDecimalString();
         return String.format("%s (%d/%d)", toDecimalString(), numerator, denominator);
-    }
-    
-    public CompoundTag toNbt() {
-        CompoundTag tag = new CompoundTag();
-        tag.putLong("n", numerator);
-        tag.putLong("d", denominator);
-        return tag;
-    }
-    
-    public static Fraction fromNbt(CompoundTag tag) {
-        long w = tag.contains("w") ? tag.getLong("w") : 0;
-        long n = tag.getLong("n");
-        long d = Math.max(1, tag.getLong("d"));
-        return of(w, n, d);
     }
 }


### PR DESCRIPTION
- Item stack data tags are serialized differently now, using a new compound tag adapter (with backwards-compatibility for the previous format)
- The item stack adapter has been touched up a bit
- Fraction is now serialized using a codec (it was previously serialized through nbt that was converted between json)

Fixes #654 and #649 (and related to #643) in 1.18.
If the PR gets accepted, I assume that I'm fine to backport it to 1.16 without going through a PR.
As this change changes the save format, it might make sense to let the next HQM version be 5.11.0. However this change is really only for code cleanup and fixing some issues, so it might not quite meet this standard. Should the next version be 5.10.1 then, rather than 5.11.0?
When this gets backported to mc 1.16, it'd be HQM 5.5.17 as HQM 5.6.x is in mc 1.17.