### PR TITLE
Quest task registry

### DIFF
--- a/common/src/main/java/hardcorequesting/common/HardcoreQuestingCore.java
+++ b/common/src/main/java/hardcorequesting/common/HardcoreQuestingCore.java
@@ -1,5 +1,6 @@
 package hardcorequesting.common;
 
+import dev.architectury.registry.registries.Registries;
 import hardcorequesting.common.client.sounds.Sounds;
 import hardcorequesting.common.commands.CommandHandler;
 import hardcorequesting.common.config.HQMConfig;
@@ -13,6 +14,7 @@ import hardcorequesting.common.platform.AbstractPlatform;
 import hardcorequesting.common.proxies.ClientProxy;
 import hardcorequesting.common.proxies.CommonProxy;
 import hardcorequesting.common.quests.QuestLine;
+import hardcorequesting.common.quests.task.TaskType;
 import hardcorequesting.common.util.Executor;
 import hardcorequesting.common.util.RegisterHelper;
 import net.minecraft.server.MinecraftServer;
@@ -78,5 +80,9 @@ public class HardcoreQuestingCore {
             PlayerDeathEventListener.instance.onLivingDeath(livingEntity, source);
             EventTrigger.instance().onLivingDeath(livingEntity, source);
         });
+        
+        Registries registries = Registries.get(HardcoreQuestingCore.ID);
+        registries.<TaskType<?>>builder(TaskType.REGISTRY_KEY.location()).syncToClients().build();
+        TaskType.REGISTER.register();
     }
 }

--- a/common/src/main/java/hardcorequesting/common/client/ClientChange.java
+++ b/common/src/main/java/hardcorequesting/common/client/ClientChange.java
@@ -174,7 +174,7 @@ public enum ClientChange {
             int task = root.get(TASK).getAsInt();
             if (quest != null && task > -1 && task < quest.getTasks().size()) {
                 QuestTask<?> taskObj = quest.getTasks().get(task);
-                if (taskObj.getType() == TaskType.CHECKBOX) {
+                if (taskObj.getType() == TaskType.CHECKBOX.get()) {
                     taskObj.completeTask(player.getUUID());
                     quest.sendUpdatedDataToTeam(player);
                 }

--- a/common/src/main/java/hardcorequesting/common/client/interfaces/widget/ExtendedScrollBar.java
+++ b/common/src/main/java/hardcorequesting/common/client/interfaces/widget/ExtendedScrollBar.java
@@ -8,22 +8,27 @@ import java.util.function.Supplier;
 public class ExtendedScrollBar<T> extends ScrollBar {
     
     private final Supplier<List<T>> listSupplier;
-    private final int visibleEntries;
+    private final int visibleRows, columns;
     
     public ExtendedScrollBar(GuiBase gui, Size size, int x, int y, int left, int visibleEntries, Supplier<List<T>> listSupplier) {
+        this(gui, size, x, y, left, visibleEntries, 1, listSupplier);
+    }
+    
+    public ExtendedScrollBar(GuiBase gui, Size size, int x, int y, int left, int visibleRows, int columns, Supplier<List<T>> listSupplier) {
         super(gui, size, x, y, left);
         this.listSupplier = listSupplier;
-        this.visibleEntries = visibleEntries;
+        this.visibleRows = visibleRows;
+        this.columns = columns;
     }
     
     @Override
     public boolean isVisible() {
         List<T> list = listSupplier.get();
-        return list != null && list.size() > visibleEntries;
+        return list != null && list.size() > visibleRows*columns;
     }
     
     public List<T> getVisibleEntries() {
         List<T> list = listSupplier.get();
-        return list == null ? null : this.getVisibleEntries(list, visibleEntries);
+        return list == null ? null : this.getVisibleEntries(list, columns, visibleRows);
     }
 }

--- a/common/src/main/java/hardcorequesting/common/client/interfaces/widget/LargeButton.java
+++ b/common/src/main/java/hardcorequesting/common/client/interfaces/widget/LargeButton.java
@@ -11,7 +11,7 @@ import net.fabricmc.api.Environment;
 import net.minecraft.locale.Language;
 import net.minecraft.network.chat.FormattedText;
 
-import java.util.List;
+import javax.annotation.Nullable;
 
 public abstract class LargeButton implements Drawable, Clickable {
     
@@ -24,7 +24,6 @@ public abstract class LargeButton implements Drawable, Clickable {
     private String description;
     private int x;
     private int y;
-    private List<FormattedText> lines;
     private final GuiBase gui;
     
     public LargeButton(GuiBase gui, String name, int x, int y) {
@@ -83,12 +82,13 @@ public abstract class LargeButton implements Drawable, Clickable {
     @Override
     @Environment(EnvType.CLIENT)
     public void renderTooltip(PoseStack matrices, int mX, int mY) {
-        if (isVisible() && description != null && inButtonBounds(mX, mY)) {
-            if (lines == null) {
-                lines = this.gui.getLinesFromText(getDescription(), 1, 200);
-            }
+        if (isVisible() && inButtonBounds(mX, mY)) {
+            FormattedText description = getDescription();
+            if (description != null) {
+                var lines = this.gui.getLinesFromText(getDescription(), 1, 200);
     
-            this.gui.renderTooltip(matrices, Language.getInstance().getVisualOrder(lines), mX + this.gui.getLeft(), mY + this.gui.getTop());
+                this.gui.renderTooltip(matrices, Language.getInstance().getVisualOrder(lines), mX + this.gui.getLeft(), mY + this.gui.getTop());
+            }
         }
     }
     
@@ -96,8 +96,9 @@ public abstract class LargeButton implements Drawable, Clickable {
         return Translator.translatable(name);
     }
     
+    @Nullable
     protected FormattedText getDescription() {
-        return Translator.translatable(description);
+        return description != null ? Translator.translatable(description) : null;
     }
     
 }

--- a/common/src/main/java/hardcorequesting/common/client/interfaces/widget/ScrollBar.java
+++ b/common/src/main/java/hardcorequesting/common/client/interfaces/widget/ScrollBar.java
@@ -96,8 +96,14 @@ public class ScrollBar implements Drawable, Clickable {
     }
     
     public <T> List<T> getVisibleEntries(List<T> list, int visibleEntries) {
-        int start = this.isVisible() ? Math.round((list.size() - visibleEntries) * this.getScroll()) : 0;
-        int end = Math.min(list.size(), start + visibleEntries);
+        return getVisibleEntries(list, 1, visibleEntries);
+    }
+    
+    public <T> List<T> getVisibleEntries(List<T> list, int columns, int visibleRows) {
+        int rows = (int) Math.ceil((double) list.size() / (double) columns);
+        int hiddenRows = rows - visibleRows;
+        int start = columns * Math.max(0, Math.round(hiddenRows * this.getScroll()));
+        int end = Math.min(list.size(), start + columns * visibleRows);
         return list.subList(start, end);
     }
     

--- a/common/src/main/java/hardcorequesting/common/io/adapter/QuestDataAdapter.java
+++ b/common/src/main/java/hardcorequesting/common/io/adapter/QuestDataAdapter.java
@@ -1,95 +1,68 @@
 package hardcorequesting.common.io.adapter;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.TypeAdapter;
-import com.google.gson.internal.Streams;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonWriter;
+import hardcorequesting.common.quests.Quest;
 import hardcorequesting.common.quests.data.QuestData;
 import hardcorequesting.common.quests.data.TaskData;
+import net.minecraft.util.GsonHelper;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class QuestDataAdapter {
+    public static final String REWARDS = "rewards";
+    public static final String COMPLETED = "completed";
+    public static final String CLAIMED = "claimed";
+    public static final String TASKS = "tasks";
+    public static final String AVAILABLE = "available";
+    public static final String TIME = "time";
     
-    public static final TypeAdapter<QuestData> QUEST_DATA_ADAPTER = new TypeAdapter<>() {
-        public static final String PLAYERS = "players";
-        public static final String REWARDS = "rewards";
-        public static final String COMPLETED = "completed";
-        public static final String CLAIMED = "claimed";
-        public static final String TASKS = "tasks";
-        public static final String TASKS_SIZE = "tasksSize";
-        public static final String AVAILABLE = "available";
-        public static final String TIME = "time";
-        
-        @Override
-        public void write(JsonWriter out, QuestData value) throws IOException {
-            out.beginObject();
-            out.name(REWARDS).beginArray();
-            for (boolean canClaim : value.getRewardsForSerialization())
-                out.value(canClaim);
-            out.endArray();
-            out.name(COMPLETED).value(value.completed);
-            out.name(CLAIMED).value(value.teamRewardClaimed);
-            out.name(AVAILABLE).value(value.available);
-            out.name(TIME).value(value.time);
-            out.name(TASKS).beginArray();
-            for (TaskData data : value.getTaskDataForSerialization()) {
-                if (data != null)
-                    QuestTaskAdapter.QUEST_DATA_TASK_ADAPTER.write(out, data);
-                else Streams.write(new JsonObject(), out);  //Add empty object to keep order of task data
-            }
-            out.endArray();
-            out.endObject();
+    public static JsonElement serialize(QuestData data) {
+        JsonObject json = new JsonObject();
+        JsonArray rewards = new JsonArray();
+        for (boolean canClaim : data.getRewardsForSerialization())
+            rewards.add(canClaim);
+        json.add(REWARDS, rewards);
+        json.addProperty(COMPLETED, data.completed);
+        json.addProperty(CLAIMED, data.teamRewardClaimed);
+        json.addProperty(AVAILABLE, data.available);
+        json.addProperty(TIME, data.time);
+        JsonArray tasks = new JsonArray();
+        for (TaskData taskData : data.getTaskDataForSerialization()) {
+            if (taskData != null)
+                tasks.add(QuestTaskAdapter.QUEST_DATA_TASK_ADAPTER.serialize(taskData));
+            else
+                tasks.add(new JsonObject());  //Add empty object to keep order of task data
         }
+        json.add(TASKS, tasks);
         
-        @Override
-        public QuestData read(JsonReader in) throws IOException {
-            QuestData data = new QuestData();
-            in.beginObject();
-            while (in.hasNext()) {
-                switch (in.nextName()) {
-                    case PLAYERS:
-                    case TASKS_SIZE:
-                        in.nextInt();   //Sizes are no longer used. Read it for backwards-compatibility
-                        break;
-                    case REWARDS:
-                        in.beginArray();
-                        List<Boolean> claimableRewards = new ArrayList<>();
-                        while (in.hasNext())
-                            claimableRewards.add(in.nextBoolean());
-                        data.setRewardsFromSerialization(claimableRewards);
-                        in.endArray();
-                        break;
-                    case COMPLETED:
-                        data.completed = in.nextBoolean();
-                        break;
-                    case CLAIMED:
-                        data.teamRewardClaimed = in.nextBoolean();
-                        break;
-                    case AVAILABLE:
-                        data.available = in.nextBoolean();
-                        break;
-                    case TIME:
-                        data.time = in.nextLong();
-                        break;
-                    case TASKS:
-                        in.beginArray();
-                        List<TaskData> taskData = new ArrayList<>();
-                        while (in.hasNext())
-                            taskData.add(QuestTaskAdapter.QUEST_DATA_TASK_ADAPTER.read(in));
-                        data.setTaskDataFromSerialization(taskData);
-                        in.endArray();
-                        break;
-                    default:
-                        break;
-                }
-            }
-            in.endObject();
-            return data;
-        }
-    };
+        return json;
+    }
     
+    public static QuestData deserialize(JsonObject json, Quest quest) {
+        Objects.requireNonNull(quest);
+        QuestData data = new QuestData();
+        
+        JsonArray rewardsJson = GsonHelper.getAsJsonArray(json, REWARDS);
+        List<Boolean> claimableRewards = new ArrayList<>();
+        for (JsonElement canClaim : rewardsJson)
+            claimableRewards.add(GsonHelper.convertToBoolean(canClaim, "reward"));
+        data.setRewardsFromSerialization(claimableRewards);
+        
+        data.completed = GsonHelper.getAsBoolean(json, COMPLETED);
+        data.teamRewardClaimed = GsonHelper.getAsBoolean(json, CLAIMED);
+        data.available = GsonHelper.getAsBoolean(json, AVAILABLE);
+        data.time = GsonHelper.getAsLong(json, TIME);
+        
+        JsonArray tasksJson = GsonHelper.getAsJsonArray(json, TASKS);
+        List<TaskData> taskData = new ArrayList<>();
+        for (JsonElement taskJson : tasksJson)
+            taskData.add(QuestTaskAdapter.QUEST_DATA_TASK_ADAPTER.deserialize(taskJson));
+        data.setTaskDataFromSerialization(taskData);
+        
+        return data;
+    }
 }

--- a/common/src/main/java/hardcorequesting/common/io/adapter/QuestDataAdapter.java
+++ b/common/src/main/java/hardcorequesting/common/io/adapter/QuestDataAdapter.java
@@ -63,7 +63,7 @@ public class QuestDataAdapter {
         
         JsonArray tasksJson = GsonHelper.getAsJsonArray(json, TASKS);
         List<TaskData> taskData = new ArrayList<>();
-        for (int i = 0; i < tasksJson.size(); i++) {
+        for (int i = 0; i < tasksJson.size() && i < quest.getTasks().size(); i++) {
             JsonElement taskJson = tasksJson.get(i);
             QuestTask<?> task = quest.getTasks().get(i);
             

--- a/common/src/main/java/hardcorequesting/common/io/adapter/QuestTaskAdapter.java
+++ b/common/src/main/java/hardcorequesting/common/io/adapter/QuestTaskAdapter.java
@@ -9,7 +9,6 @@ import com.google.gson.stream.JsonWriter;
 import com.mojang.datafixers.util.Either;
 import dev.architectury.fluid.FluidStack;
 import hardcorequesting.common.quests.ItemPrecision;
-import hardcorequesting.common.quests.data.*;
 import hardcorequesting.common.quests.task.CompleteQuestTask;
 import hardcorequesting.common.quests.task.QuestTask;
 import hardcorequesting.common.quests.task.TaskType;
@@ -30,29 +29,11 @@ import net.minecraft.world.item.ItemStack;
 
 import java.io.IOException;
 import java.util.*;
-import java.util.function.Function;
 
 import static hardcorequesting.common.io.adapter.QuestAdapter.QUEST;
 
 public class QuestTaskAdapter {
     
-    public static final Adapter<TaskData> QUEST_DATA_TASK_ADAPTER = new Adapter<>() {
-        private static final String TYPE = "type";
-    
-        @Override
-        public JsonElement serialize(TaskData src) {
-            JsonObjectBuilder builder = object()
-                    .add(TYPE, String.valueOf(src.getDataType()));
-            src.write(builder);
-            return builder.build();
-        }
-    
-        @Override
-        public TaskData deserialize(JsonElement json) {
-            JsonObject object = json.getAsJsonObject();
-            return QuestDataType.valueOf(GsonHelper.getAsString(object, TYPE)).construct(object);
-        }
-    };
     public static final TypeAdapter<ItemRequirementTask.Part> ITEM_REQUIREMENT_ADAPTER = new TypeAdapter<>() {
         private static final String ITEM = "item";
         private static final String FLUID = "fluid";
@@ -409,28 +390,6 @@ public class QuestTaskAdapter {
             return TASK;
         }
     };
-    
-    public enum QuestDataType {
-        GENERIC(TaskData::construct),
-        DEATH(DeathTaskData::construct),
-        ITEMS(ItemsTaskData::construct),
-        LOCATION(LocationTaskData::construct),
-        MOB(MobTaskData::construct),
-        REPUTATION_KILL(ReputationKillTaskData::construct),
-        TAME(TameTaskData::construct),
-        ADVANCEMENT(AdvancementTaskData::construct),
-        COMPLETED(CompleteQuestTaskData::construct);
-        
-        private final Function<JsonObject, TaskData> func;
-        
-        QuestDataType(Function<JsonObject, TaskData> func) {
-            this.func = func;
-        }
-        
-        public TaskData construct(JsonObject in) {
-            return func.apply(in);
-        }
-    }
     
     public static class ReputationSettingConstructor {
         private static final String REPUTATION = "reputation";

--- a/common/src/main/java/hardcorequesting/common/io/adapter/TeamAdapter.java
+++ b/common/src/main/java/hardcorequesting/common/io/adapter/TeamAdapter.java
@@ -3,6 +3,7 @@ package hardcorequesting.common.io.adapter;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
+import hardcorequesting.common.quests.Quest;
 import hardcorequesting.common.quests.data.QuestData;
 import hardcorequesting.common.reputation.Reputation;
 import hardcorequesting.common.reputation.ReputationManager;
@@ -58,7 +59,7 @@ public class TeamAdapter {
                                 for (Map.Entry<UUID, QuestData> data : src.getQuestData().entrySet()) {
                                     builder.add(object()
                                             .add(QUEST_ID, data.getKey().toString())
-                                            .add(QUEST_DATA, QuestDataAdapter.QUEST_DATA_ADAPTER.toJsonTree(data.getValue()))
+                                            .add(QUEST_DATA, QuestDataAdapter.serialize(data.getValue()))
                                             .build());
                                 }
                             })
@@ -95,9 +96,10 @@ public class TeamAdapter {
             }
             for (JsonElement element : GsonHelper.getAsJsonArray(object, QUEST_DATA_LIST)) {
                 JsonObject questDataObject = element.getAsJsonObject();
+                UUID questId = UUID.fromString(GsonHelper.getAsString(questDataObject, QUEST_ID));
                 team.getQuestData().put(
-                        UUID.fromString(GsonHelper.getAsString(questDataObject, QUEST_ID)),
-                        QuestDataAdapter.QUEST_DATA_ADAPTER.fromJsonTree(questDataObject.get(QUEST_DATA))
+                        questId,
+                        QuestDataAdapter.deserialize(GsonHelper.getAsJsonObject(questDataObject, QUEST_DATA), Quest.getQuest(questId))
                 );
             }
             for (JsonElement element : GsonHelper.getAsJsonArray(object, INVITES)) {

--- a/common/src/main/java/hardcorequesting/common/network/message/QuestDataUpdateMessage.java
+++ b/common/src/main/java/hardcorequesting/common/network/message/QuestDataUpdateMessage.java
@@ -1,5 +1,6 @@
 package hardcorequesting.common.network.message;
 
+import com.google.gson.*;
 import hardcorequesting.common.HardcoreQuestingCore;
 import hardcorequesting.common.io.adapter.QuestDataAdapter;
 import hardcorequesting.common.network.IMessage;
@@ -15,6 +16,7 @@ import java.util.UUID;
 
 public class QuestDataUpdateMessage implements IMessage {
     
+    private static final Gson GSON = new Gson();
     private UUID questId;
     private String data;
     private int players;
@@ -24,7 +26,7 @@ public class QuestDataUpdateMessage implements IMessage {
     
     public QuestDataUpdateMessage(UUID questId, int players, QuestData data) {
         this.questId = questId;
-        this.data = QuestDataAdapter.QUEST_DATA_ADAPTER.toJson(data);
+        this.data = GSON.toJson(QuestDataAdapter.serialize(data));
         this.players = players;
     }
     
@@ -54,12 +56,12 @@ public class QuestDataUpdateMessage implements IMessage {
         
         private void handle(QuestDataUpdateMessage message, PacketContext ctx) {
             try {
-                QuestData data = QuestDataAdapter.QUEST_DATA_ADAPTER.fromJson(message.data);
                 Quest quest = Quest.getQuest(message.questId);
                 if (quest != null) {
+                    QuestData data = QuestDataAdapter.deserialize(GSON.fromJson(message.data, JsonObject.class), quest);
                     quest.setQuestData(HardcoreQuestingCore.proxy.getPlayer(ctx), data);
                 }
-            } catch (IOException ignored) {
+            } catch (JsonSyntaxException ignored) {
             }
         }
     }

--- a/common/src/main/java/hardcorequesting/common/proxies/ClientProxy.java
+++ b/common/src/main/java/hardcorequesting/common/proxies/ClientProxy.java
@@ -1,5 +1,6 @@
 package hardcorequesting.common.proxies;
 
+import dev.architectury.event.events.client.ClientLifecycleEvent;
 import hardcorequesting.common.HardcoreQuestingCore;
 import hardcorequesting.common.client.interfaces.graphic.task.*;
 import hardcorequesting.common.network.PacketContext;
@@ -16,22 +17,26 @@ public class ClientProxy extends CommonProxy {
         super.init();
         Quest.clientTicker = new QuestTicker();
         HardcoreQuestingCore.platform.registerOnClientTick(minecraftClient -> Quest.clientTicker.tick(minecraftClient.level, true));
-
-        TaskGraphics.register(TaskType.CHECKBOX, CheckBoxTaskGraphic::new);
-        TaskGraphics.register(TaskType.CONSUME, (task, playerId, questBook) -> ItemTaskGraphic.createConsumeGraphic(task, playerId, questBook, true));
-        TaskGraphics.register(TaskType.CRAFT, ItemTaskGraphic::new);
-        TaskGraphics.register(TaskType.LOCATION, LocationTaskGraphic::new);
-        TaskGraphics.register(TaskType.CONSUME_QDS, (task, playerId, questBook) -> ItemTaskGraphic.createConsumeGraphic(task, playerId, questBook, false));
-        TaskGraphics.register(TaskType.DETECT, ItemTaskGraphic::createDetectGraphic);
-        TaskGraphics.register(TaskType.KILL, KillMobsTaskGraphic::new);
-        TaskGraphics.register(TaskType.TAME, TameMobsTaskGraphic::new);
-        TaskGraphics.register(TaskType.DEATH, DeathTaskGraphic::new);
-        TaskGraphics.register(TaskType.REPUTATION, ReputationTaskGraphic::new);
-        TaskGraphics.register(TaskType.REPUTATION_KILL, KillReputationTaskGraphic::new);
-        TaskGraphics.register(TaskType.ADVANCEMENT, AdvancementTaskGraphic::new);
-        TaskGraphics.register(TaskType.COMPLETION, CompleteQuestTaskGraphic::new);
-        TaskGraphics.register(TaskType.BLOCK_BREAK, ItemTaskGraphic::new);
-        TaskGraphics.register(TaskType.BLOCK_PLACE, ItemTaskGraphic::new);
+        ClientLifecycleEvent.CLIENT_SETUP.register(instance -> setupTaskGraphics());
+    }
+    
+    // Has to be done after our task types have been initialized, so we do this at the client setup event
+    private static void setupTaskGraphics() {
+        TaskGraphics.register(TaskType.CHECKBOX.get(), CheckBoxTaskGraphic::new);
+        TaskGraphics.register(TaskType.CONSUME.get(), (task, playerId, questBook) -> ItemTaskGraphic.createConsumeGraphic(task, playerId, questBook, true));
+        TaskGraphics.register(TaskType.CRAFT.get(), ItemTaskGraphic::new);
+        TaskGraphics.register(TaskType.LOCATION.get(), LocationTaskGraphic::new);
+        TaskGraphics.register(TaskType.CONSUME_QDS.get(), (task, playerId, questBook) -> ItemTaskGraphic.createConsumeGraphic(task, playerId, questBook, false));
+        TaskGraphics.register(TaskType.DETECT.get(), ItemTaskGraphic::createDetectGraphic);
+        TaskGraphics.register(TaskType.KILL.get(), KillMobsTaskGraphic::new);
+        TaskGraphics.register(TaskType.TAME.get(), TameMobsTaskGraphic::new);
+        TaskGraphics.register(TaskType.DEATH.get(), DeathTaskGraphic::new);
+        TaskGraphics.register(TaskType.REPUTATION.get(), ReputationTaskGraphic::new);
+        TaskGraphics.register(TaskType.REPUTATION_KILL.get(), KillReputationTaskGraphic::new);
+        TaskGraphics.register(TaskType.ADVANCEMENT.get(), AdvancementTaskGraphic::new);
+        TaskGraphics.register(TaskType.COMPLETION.get(), CompleteQuestTaskGraphic::new);
+        TaskGraphics.register(TaskType.BLOCK_BREAK.get(), ItemTaskGraphic::new);
+        TaskGraphics.register(TaskType.BLOCK_PLACE.get(), ItemTaskGraphic::new);
     }
     
     @Override

--- a/common/src/main/java/hardcorequesting/common/quests/data/AdvancementTaskData.java
+++ b/common/src/main/java/hardcorequesting/common/quests/data/AdvancementTaskData.java
@@ -3,7 +3,6 @@ package hardcorequesting.common.quests.data;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import hardcorequesting.common.io.adapter.Adapter;
-import hardcorequesting.common.io.adapter.QuestTaskAdapter;
 import net.minecraft.util.GsonHelper;
 
 import java.util.ArrayList;
@@ -23,7 +22,7 @@ public class AdvancementTaskData extends TaskData {
         }
     }
     
-    public static TaskData construct(JsonObject in) {
+    public static AdvancementTaskData construct(JsonObject in) {
         AdvancementTaskData data = new AdvancementTaskData(GsonHelper.getAsInt(in, COUNT));
         data.completed = GsonHelper.getAsBoolean(in, COMPLETED, false);
         JsonArray array = GsonHelper.getAsJsonArray(in, ADVANCED);
@@ -60,11 +59,6 @@ public class AdvancementTaskData extends TaskData {
     
     public boolean areAllCompleted(int size) {
         return advanced.stream().limit(size).allMatch(Boolean::booleanValue);
-    }
-    
-    @Override
-    public QuestTaskAdapter.QuestDataType getDataType() {
-        return QuestTaskAdapter.QuestDataType.ADVANCEMENT;
     }
     
     @Override

--- a/common/src/main/java/hardcorequesting/common/quests/data/CompleteQuestTaskData.java
+++ b/common/src/main/java/hardcorequesting/common/quests/data/CompleteQuestTaskData.java
@@ -3,7 +3,6 @@ package hardcorequesting.common.quests.data;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import hardcorequesting.common.io.adapter.Adapter;
-import hardcorequesting.common.io.adapter.QuestTaskAdapter;
 import net.minecraft.util.GsonHelper;
 
 import java.util.ArrayList;
@@ -22,7 +21,7 @@ public class CompleteQuestTaskData extends TaskData {
         }
     }
     
-    public static TaskData construct(JsonObject in) {
+    public static CompleteQuestTaskData construct(JsonObject in) {
         CompleteQuestTaskData data = new CompleteQuestTaskData(GsonHelper.getAsInt(in, COUNT));
         data.completed = GsonHelper.getAsBoolean(in, COMPLETED, false);
         JsonArray array = GsonHelper.getAsJsonArray(in, QUESTS);
@@ -59,11 +58,6 @@ public class CompleteQuestTaskData extends TaskData {
     
     public boolean areAllCompleted(int size) {
         return quests.stream().limit(size).allMatch(Boolean::booleanValue);
-    }
-    
-    @Override
-    public QuestTaskAdapter.QuestDataType getDataType() {
-        return QuestTaskAdapter.QuestDataType.COMPLETED;
     }
     
     @Override

--- a/common/src/main/java/hardcorequesting/common/quests/data/DeathTaskData.java
+++ b/common/src/main/java/hardcorequesting/common/quests/data/DeathTaskData.java
@@ -3,7 +3,6 @@ package hardcorequesting.common.quests.data;
 
 import com.google.gson.JsonObject;
 import hardcorequesting.common.io.adapter.Adapter;
-import hardcorequesting.common.io.adapter.QuestTaskAdapter;
 import net.minecraft.util.GsonHelper;
 
 public class DeathTaskData extends TaskData {
@@ -15,7 +14,7 @@ public class DeathTaskData extends TaskData {
         super();
     }
     
-    public static TaskData construct(JsonObject in) {
+    public static DeathTaskData construct(JsonObject in) {
         DeathTaskData data = new DeathTaskData();
         data.completed = GsonHelper.getAsBoolean(in, COMPLETED, false);
         data.deaths = GsonHelper.getAsInt(in, DEATHS);
@@ -32,11 +31,6 @@ public class DeathTaskData extends TaskData {
     
     public void merge(DeathTaskData data) {
         deaths = Math.max(this.deaths, data.deaths);
-    }
-    
-    @Override
-    public QuestTaskAdapter.QuestDataType getDataType() {
-        return QuestTaskAdapter.QuestDataType.DEATH;
     }
     
     @Override

--- a/common/src/main/java/hardcorequesting/common/quests/data/ItemsTaskData.java
+++ b/common/src/main/java/hardcorequesting/common/quests/data/ItemsTaskData.java
@@ -4,7 +4,6 @@ package hardcorequesting.common.quests.data;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import hardcorequesting.common.io.adapter.Adapter;
-import hardcorequesting.common.io.adapter.QuestTaskAdapter;
 import hardcorequesting.common.quests.task.item.ItemRequirementTask;
 import net.minecraft.util.GsonHelper;
 
@@ -25,7 +24,7 @@ public class ItemsTaskData extends TaskData {
         }
     }
     
-    public static TaskData construct(JsonObject in) {
+    public static ItemsTaskData construct(JsonObject in) {
         ItemsTaskData data = new ItemsTaskData(GsonHelper.getAsInt(in, COUNT));
         data.completed = GsonHelper.getAsBoolean(in, COMPLETED, false);
         JsonArray array = GsonHelper.getAsJsonArray(in, PROGRESS);
@@ -56,11 +55,6 @@ public class ItemsTaskData extends TaskData {
     
     public boolean isDone(int index, ItemRequirementTask.Part requirement) {
         return this.getValue(index) >= requirement.required;
-    }
-    
-    @Override
-    public QuestTaskAdapter.QuestDataType getDataType() {
-        return QuestTaskAdapter.QuestDataType.ITEMS;
     }
     
     @Override

--- a/common/src/main/java/hardcorequesting/common/quests/data/LocationTaskData.java
+++ b/common/src/main/java/hardcorequesting/common/quests/data/LocationTaskData.java
@@ -4,7 +4,6 @@ package hardcorequesting.common.quests.data;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import hardcorequesting.common.io.adapter.Adapter;
-import hardcorequesting.common.io.adapter.QuestTaskAdapter;
 import net.minecraft.util.GsonHelper;
 
 import java.util.ArrayList;
@@ -24,7 +23,7 @@ public class LocationTaskData extends TaskData {
         }
     }
     
-    public static TaskData construct(JsonObject in) {
+    public static LocationTaskData construct(JsonObject in) {
         LocationTaskData data = new LocationTaskData(GsonHelper.getAsInt(in, COUNT));
         data.completed = GsonHelper.getAsBoolean(in, COMPLETED, false);
         JsonArray array = GsonHelper.getAsJsonArray(in, VISITED);
@@ -61,11 +60,6 @@ public class LocationTaskData extends TaskData {
     
     public boolean areAllCompleted(int size) {
         return visited.stream().limit(size).allMatch(Boolean::booleanValue);
-    }
-    
-    @Override
-    public QuestTaskAdapter.QuestDataType getDataType() {
-        return QuestTaskAdapter.QuestDataType.LOCATION;
     }
     
     @Override

--- a/common/src/main/java/hardcorequesting/common/quests/data/MobTaskData.java
+++ b/common/src/main/java/hardcorequesting/common/quests/data/MobTaskData.java
@@ -4,7 +4,6 @@ package hardcorequesting.common.quests.data;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import hardcorequesting.common.io.adapter.Adapter;
-import hardcorequesting.common.io.adapter.QuestTaskAdapter;
 import net.minecraft.util.GsonHelper;
 
 import java.util.ArrayList;
@@ -24,7 +23,7 @@ public class MobTaskData extends TaskData {
         }
     }
     
-    public static TaskData construct(JsonObject in) {
+    public static MobTaskData construct(JsonObject in) {
         MobTaskData data = new MobTaskData(GsonHelper.getAsInt(in, COUNT));
         data.completed = GsonHelper.getAsBoolean(in, COMPLETED, false);
         JsonArray array = GsonHelper.getAsJsonArray(in, KILLED);
@@ -51,11 +50,6 @@ public class MobTaskData extends TaskData {
         for (int i = 0; i < other.killed.size(); i++) {
             setValue(i, Math.max(this.getValue(i), other.getValue(i)));
         }
-    }
-    
-    @Override
-    public QuestTaskAdapter.QuestDataType getDataType() {
-        return QuestTaskAdapter.QuestDataType.MOB;
     }
     
     @Override

--- a/common/src/main/java/hardcorequesting/common/quests/data/ReputationKillTaskData.java
+++ b/common/src/main/java/hardcorequesting/common/quests/data/ReputationKillTaskData.java
@@ -3,7 +3,6 @@ package hardcorequesting.common.quests.data;
 
 import com.google.gson.JsonObject;
 import hardcorequesting.common.io.adapter.Adapter;
-import hardcorequesting.common.io.adapter.QuestTaskAdapter;
 import net.minecraft.util.GsonHelper;
 
 public class ReputationKillTaskData extends TaskData {
@@ -15,16 +14,11 @@ public class ReputationKillTaskData extends TaskData {
         super();
     }
     
-    public static TaskData construct(JsonObject in) {
+    public static ReputationKillTaskData construct(JsonObject in) {
         ReputationKillTaskData data = new ReputationKillTaskData();
         data.completed = GsonHelper.getAsBoolean(in, COMPLETED, false);
         data.kills = GsonHelper.getAsInt(in, KILLS);
         return data;
-    }
-    
-    @Override
-    public QuestTaskAdapter.QuestDataType getDataType() {
-        return QuestTaskAdapter.QuestDataType.REPUTATION_KILL;
     }
     
     @Override

--- a/common/src/main/java/hardcorequesting/common/quests/data/TameTaskData.java
+++ b/common/src/main/java/hardcorequesting/common/quests/data/TameTaskData.java
@@ -4,7 +4,6 @@ package hardcorequesting.common.quests.data;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import hardcorequesting.common.io.adapter.Adapter;
-import hardcorequesting.common.io.adapter.QuestTaskAdapter;
 import net.minecraft.util.GsonHelper;
 
 import java.util.ArrayList;
@@ -24,7 +23,7 @@ public class TameTaskData extends TaskData {
         }
     }
     
-    public static TaskData construct(JsonObject in) {
+    public static TameTaskData construct(JsonObject in) {
         TameTaskData data = new TameTaskData(GsonHelper.getAsInt(in, COUNT));
         data.completed = GsonHelper.getAsBoolean(in, COMPLETED, false);
         JsonArray array = GsonHelper.getAsJsonArray(in, TAMED);
@@ -51,11 +50,6 @@ public class TameTaskData extends TaskData {
         for (int i = 0; i < other.tamed.size(); i++) {
             setValue(i, Math.max(this.getValue(i), other.getValue(i)));
         }
-    }
-    
-    @Override
-    public QuestTaskAdapter.QuestDataType getDataType() {
-        return QuestTaskAdapter.QuestDataType.TAME;
     }
     
     @Override

--- a/common/src/main/java/hardcorequesting/common/quests/data/TaskData.java
+++ b/common/src/main/java/hardcorequesting/common/quests/data/TaskData.java
@@ -3,7 +3,6 @@ package hardcorequesting.common.quests.data;
 
 import com.google.gson.JsonObject;
 import hardcorequesting.common.io.adapter.Adapter;
-import hardcorequesting.common.io.adapter.QuestTaskAdapter;
 import net.minecraft.util.GsonHelper;
 
 public class TaskData {
@@ -18,10 +17,6 @@ public class TaskData {
         TaskData data = new TaskData();
         data.completed = GsonHelper.getAsBoolean(in, COMPLETED, false);
         return data;
-    }
-    
-    public QuestTaskAdapter.QuestDataType getDataType() {
-        return QuestTaskAdapter.QuestDataType.GENERIC;
     }
     
     public void write(Adapter.JsonObjectBuilder builder) {

--- a/common/src/main/java/hardcorequesting/common/quests/task/CheckBoxTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/CheckBoxTask.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 
 public class CheckBoxTask extends QuestTask<TaskData> {
     public CheckBoxTask(Quest parent) {
-        super(TaskType.CHECKBOX, TaskData.class, parent);
+        super(TaskType.CHECKBOX.get(), TaskData.class, parent);
     }
 
     @Override

--- a/common/src/main/java/hardcorequesting/common/quests/task/CheckBoxTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/CheckBoxTask.java
@@ -18,7 +18,12 @@ public class CheckBoxTask extends QuestTask<TaskData> {
     public TaskData newQuestData() {
         return new TaskData();
     }
-
+    
+    @Override
+    public TaskData loadData(JsonObject json) {
+        return TaskData.construct(json);
+    }
+    
     @Override
     public void onUpdate(Player player) {
 

--- a/common/src/main/java/hardcorequesting/common/quests/task/CompleteQuestTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/CompleteQuestTask.java
@@ -52,6 +52,11 @@ public class CompleteQuestTask extends QuestTask<CompleteQuestTaskData> {
     }
     
     @Override
+    public CompleteQuestTaskData loadData(JsonObject json) {
+        return CompleteQuestTaskData.construct(json);
+    }
+    
+    @Override
     public void onQuestCompleted(EventTrigger.QuestCompletedEvent event) {
         checkCompleted(event.getPlayer());
     }

--- a/common/src/main/java/hardcorequesting/common/quests/task/CompleteQuestTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/CompleteQuestTask.java
@@ -28,7 +28,7 @@ public class CompleteQuestTask extends QuestTask<CompleteQuestTaskData> {
     private final PartList<Part> parts = new PartList<>(Part::new, EditType.Type.COMPLETION, LIMIT);
     
     public CompleteQuestTask(Quest parent) {
-        super(TaskType.COMPLETION, CompleteQuestTaskData.class, parent);
+        super(TaskType.COMPLETION.get(), CompleteQuestTaskData.class, parent);
         
         register(EventTrigger.Type.QUEST_COMPLETED, EventTrigger.Type.OPEN_BOOK);
     }

--- a/common/src/main/java/hardcorequesting/common/quests/task/DeathTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/DeathTask.java
@@ -22,7 +22,7 @@ public class DeathTask extends QuestTask<DeathTaskData> {
     private int deaths;
     
     public DeathTask(Quest parent) {
-        super(TaskType.DEATH, DeathTaskData.class, parent);
+        super(TaskType.DEATH.get(), DeathTaskData.class, parent);
         
         register(EventTrigger.Type.DEATH);
     }

--- a/common/src/main/java/hardcorequesting/common/quests/task/DeathTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/DeathTask.java
@@ -33,6 +33,11 @@ public class DeathTask extends QuestTask<DeathTaskData> {
     }
     
     @Override
+    public DeathTaskData loadData(JsonObject json) {
+        return DeathTaskData.construct(json);
+    }
+    
+    @Override
     public void onUpdate(Player player) {
         
     }

--- a/common/src/main/java/hardcorequesting/common/quests/task/QuestTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/QuestTask.java
@@ -1,12 +1,10 @@
 package hardcorequesting.common.quests.task;
 
 import com.google.gson.JsonObject;
-import com.google.gson.stream.JsonReader;
 import hardcorequesting.common.client.ClientChange;
 import hardcorequesting.common.client.sounds.Sounds;
 import hardcorequesting.common.event.EventTrigger;
 import hardcorequesting.common.io.adapter.Adapter;
-import hardcorequesting.common.io.adapter.QuestTaskAdapter;
 import hardcorequesting.common.network.NetworkManager;
 import hardcorequesting.common.quests.Quest;
 import hardcorequesting.common.quests.QuestingData;
@@ -33,7 +31,6 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 
-import java.io.IOException;
 import java.util.UUID;
 
 public abstract class QuestTask<Data extends TaskData> {
@@ -122,14 +119,6 @@ public abstract class QuestTask<Data extends TaskData> {
             return requirement.isCompleted(playerId) && requirement.isVisible(playerId);
         }
         else return true;
-    }
-    
-    public void write(TaskData task, JsonObject out) {
-        task.write(new Adapter.JsonObjectBuilder(out));
-    }
-    
-    public void read(TaskData task, JsonReader in) throws IOException {
-        task.update(QuestTaskAdapter.QUEST_DATA_TASK_ADAPTER.read(in));
     }
     
     protected Data getData(Player player) {

--- a/common/src/main/java/hardcorequesting/common/quests/task/QuestTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/QuestTask.java
@@ -143,6 +143,8 @@ public abstract class QuestTask<Data extends TaskData> {
     
     public abstract Data newQuestData();
     
+    public abstract Data loadData(JsonObject json);
+    
     public MutableComponent getName() {
         return name.getText();
     }

--- a/common/src/main/java/hardcorequesting/common/quests/task/TaskType.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/TaskType.java
@@ -1,6 +1,8 @@
 package hardcorequesting.common.quests.task;
 
-import com.google.common.collect.ImmutableMap;
+import dev.architectury.registry.registries.DeferredRegister;
+import dev.architectury.registry.registries.RegistrySupplier;
+import hardcorequesting.common.HardcoreQuestingCore;
 import hardcorequesting.common.quests.Quest;
 import hardcorequesting.common.quests.task.icon.GetAdvancementTask;
 import hardcorequesting.common.quests.task.icon.KillMobsTask;
@@ -12,32 +14,35 @@ import hardcorequesting.common.quests.task.reputation.KillReputationTask;
 import hardcorequesting.common.util.EditType;
 import hardcorequesting.common.util.SaveHelper;
 import hardcorequesting.common.util.Translator;
+import net.minecraft.core.Registry;
 import net.minecraft.network.chat.FormattedText;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
 
-import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 
 public final class TaskType<T extends QuestTask<?>> {
-    public static final TaskType<CheckBoxTask> CHECKBOX = new TaskType<>("checkbox", CheckBoxTask::new);
-    public static final TaskType<ConsumeItemTask> CONSUME = new TaskType<>("consume", ConsumeItemTask::new);
-    public static final TaskType<CraftingTask> CRAFT = new TaskType<>("craft", CraftingTask::new);
-    public static final TaskType<VisitLocationTask> LOCATION = new TaskType<>("location", VisitLocationTask::new);
-    public static final TaskType<ConsumeItemQDSTask> CONSUME_QDS = new TaskType<>("consumeQDS", ConsumeItemQDSTask::new);
-    public static final TaskType<DetectItemTask> DETECT = new TaskType<>("detect", DetectItemTask::new);
-    public static final TaskType<KillMobsTask> KILL = new TaskType<>("kill", KillMobsTask::new);
-    public static final TaskType<TameMobsTask> TAME = new TaskType<>("tame", TameMobsTask::new);
-    public static final TaskType<DeathTask> DEATH = new TaskType<>("death", DeathTask::new);
-    public static final TaskType<HaveReputationTask> REPUTATION = new TaskType<>("reputation", HaveReputationTask::new);
-    public static final TaskType<KillReputationTask> REPUTATION_KILL = new TaskType<>("reputationKill", KillReputationTask::new);
-    public static final TaskType<GetAdvancementTask> ADVANCEMENT = new TaskType<>("advancement", GetAdvancementTask::new);
-    public static final TaskType<CompleteQuestTask> COMPLETION = new TaskType<>("completion", CompleteQuestTask::new);
-    public static final TaskType<BreakBlockTask> BLOCK_BREAK = new TaskType<>("break", BreakBlockTask::new);
-    public static final TaskType<PlaceBlockTask> BLOCK_PLACE = new TaskType<>("place", PlaceBlockTask::new);
+    public static final ResourceKey<Registry<TaskType<?>>> REGISTRY_KEY = ResourceKey.createRegistryKey(new ResourceLocation(HardcoreQuestingCore.ID, "task_type"));
+    public static final DeferredRegister<TaskType<?>> REGISTER = DeferredRegister.create(HardcoreQuestingCore.ID, REGISTRY_KEY);
     
-    private static final Map<String, TaskType<?>> TYPES = ImmutableMap.<String, TaskType<?>>builder().put("CHECKBOX", CHECKBOX).put("CONSUME", CONSUME).put("CRAFT", CRAFT)
-            .put("LOCATION", LOCATION).put("CONSUME_QDS", CONSUME_QDS).put("DETECT", DETECT).put("KILL", KILL).put("TAME", TAME).put("DEATH", DEATH)
-            .put("REPUTATION", REPUTATION).put("REPUTATION_KILL", REPUTATION_KILL).put("ADVANCEMENT", ADVANCEMENT).put("COMPLETION", COMPLETION)
-            .put("BLOCK_BREAK", BLOCK_BREAK).put("BLOCK_PLACE", BLOCK_PLACE).build();
+    public static final RegistrySupplier<TaskType<CheckBoxTask>> CHECKBOX = REGISTER.register("checkbox", () -> new TaskType<>("checkbox", CheckBoxTask::new));
+    public static final RegistrySupplier<TaskType<ConsumeItemTask>> CONSUME = REGISTER.register("consume", () -> new TaskType<>("consume", ConsumeItemTask::new));
+    public static final RegistrySupplier<TaskType<CraftingTask>> CRAFT = REGISTER.register("craft", () -> new TaskType<>("craft", CraftingTask::new));
+    public static final RegistrySupplier<TaskType<VisitLocationTask>> LOCATION = REGISTER.register("location", () -> new TaskType<>("location", VisitLocationTask::new));
+    public static final RegistrySupplier<TaskType<ConsumeItemQDSTask>> CONSUME_QDS = REGISTER.register("consume_qds", () -> new TaskType<>("consumeQDS", ConsumeItemQDSTask::new));
+    public static final RegistrySupplier<TaskType<DetectItemTask>> DETECT = REGISTER.register("detect", () -> new TaskType<>("detect", DetectItemTask::new));
+    public static final RegistrySupplier<TaskType<KillMobsTask>> KILL = REGISTER.register("kill", () -> new TaskType<>("kill", KillMobsTask::new));
+    public static final RegistrySupplier<TaskType<TameMobsTask>> TAME = REGISTER.register("tame", () -> new TaskType<>("tame", TameMobsTask::new));
+    public static final RegistrySupplier<TaskType<DeathTask>> DEATH = REGISTER.register("death", () -> new TaskType<>("death", DeathTask::new));
+    public static final RegistrySupplier<TaskType<HaveReputationTask>> REPUTATION = REGISTER.register("reputation", () -> new TaskType<>("reputation", HaveReputationTask::new));
+    public static final RegistrySupplier<TaskType<KillReputationTask>> REPUTATION_KILL = REGISTER.register("reputation_kill", () -> new TaskType<>("reputationKill", KillReputationTask::new));
+    public static final RegistrySupplier<TaskType<GetAdvancementTask>> ADVANCEMENT = REGISTER.register("advancement", () -> new TaskType<>("advancement", GetAdvancementTask::new));
+    public static final RegistrySupplier<TaskType<CompleteQuestTask>> COMPLETION = REGISTER.register("completion", () -> new TaskType<>("completion", CompleteQuestTask::new));
+    public static final RegistrySupplier<TaskType<BreakBlockTask>> BLOCK_BREAK = REGISTER.register("block_break", () -> new TaskType<>("break", BreakBlockTask::new));
+    public static final RegistrySupplier<TaskType<PlaceBlockTask>> BLOCK_PLACE = REGISTER.register("block_place", () -> new TaskType<>("place", PlaceBlockTask::new));
     
     private final String id;
     private final TaskConstructor<T> constructor;
@@ -47,23 +52,27 @@ public final class TaskType<T extends QuestTask<?>> {
         this.constructor = constructor;
     }
     
-    public static Collection<TaskType<?>> values() {
-        return TYPES.values();
+    public static List<? extends TaskType<?>> values() {
+        return REGISTER.getRegistrar().entrySet().stream().map(Map.Entry::getValue).toList();
     }
     
     public String toDataName() {
-        for (Map.Entry<String, TaskType<?>> entry : TYPES.entrySet()) {
-            if (entry.getValue() == this)
-                return entry.getKey();
-        }
-        throw new IllegalStateException(id + " is not registered as a task type");
+        return String.valueOf(REGISTER.getRegistrar().getId(this));
     }
     
     public static TaskType<?> fromDataName(String str) {
-        TaskType<?> type = TYPES.get(str);
+        ResourceLocation id = ResourceLocation.tryParse(str);
+        
+        // If parsing fails (potentially due to upper-case characters),
+        // try converting from the previous upper-case and modid-free format to the current format
+        if (id == null)
+            id = Objects.requireNonNull(ResourceLocation.tryBuild(HardcoreQuestingCore.ID, str.toLowerCase(Locale.ROOT)),
+                    () -> "Not a valid task type name: %s".formatted(str));
+        
+        TaskType<?> type = REGISTER.getRegistrar().get(id);
         if (type != null)
             return type;
-        else throw new IllegalArgumentException(str + " is not a valid task type name");
+        else throw new IllegalArgumentException("Not a valid task type name: %s".formatted(str));
     }
     
     public T addTask(Quest quest) {

--- a/common/src/main/java/hardcorequesting/common/quests/task/icon/GetAdvancementTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/icon/GetAdvancementTask.java
@@ -53,6 +53,11 @@ public class GetAdvancementTask extends IconLayoutTask<GetAdvancementTask.Part, 
     }
     
     @Override
+    public AdvancementTaskData loadData(JsonObject json) {
+        return AdvancementTaskData.construct(json);
+    }
+    
+    @Override
     public void onAdvancement(ServerPlayer playerEntity) {
         checkAdvancement(playerEntity);
     }

--- a/common/src/main/java/hardcorequesting/common/quests/task/icon/GetAdvancementTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/icon/GetAdvancementTask.java
@@ -29,7 +29,7 @@ public class GetAdvancementTask extends IconLayoutTask<GetAdvancementTask.Part, 
     private static final String ADVANCEMENTS = "advancements";
     
     public GetAdvancementTask(Quest parent) {
-        super(TaskType.ADVANCEMENT, AdvancementTaskData.class, EditType.Type.ADVANCEMENT, parent);
+        super(TaskType.ADVANCEMENT.get(), AdvancementTaskData.class, EditType.Type.ADVANCEMENT, parent);
         
         register(EventTrigger.Type.ADVANCEMENT, EventTrigger.Type.OPEN_BOOK);
     }

--- a/common/src/main/java/hardcorequesting/common/quests/task/icon/KillMobsTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/icon/KillMobsTask.java
@@ -63,6 +63,11 @@ public class KillMobsTask extends IconLayoutTask<KillMobsTask.Part, MobTaskData>
     }
     
     @Override
+    public MobTaskData loadData(JsonObject json) {
+        return MobTaskData.construct(json);
+    }
+    
+    @Override
     public void onUpdate(Player player) {
         
     }

--- a/common/src/main/java/hardcorequesting/common/quests/task/icon/KillMobsTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/icon/KillMobsTask.java
@@ -28,7 +28,7 @@ public class KillMobsTask extends IconLayoutTask<KillMobsTask.Part, MobTaskData>
     private static final String MOBS = "mobs";
     
     public KillMobsTask(Quest parent) {
-        super(TaskType.KILL, MobTaskData.class, EditType.Type.MONSTER, parent);
+        super(TaskType.KILL.get(), MobTaskData.class, EditType.Type.MONSTER, parent);
         register(EventTrigger.Type.DEATH);
     }
     

--- a/common/src/main/java/hardcorequesting/common/quests/task/icon/TameMobsTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/icon/TameMobsTask.java
@@ -74,6 +74,11 @@ public class TameMobsTask extends IconLayoutTask<TameMobsTask.Part, TameTaskData
     }
     
     @Override
+    public TameTaskData loadData(JsonObject json) {
+        return TameTaskData.construct(json);
+    }
+    
+    @Override
     public void onUpdate(Player player) {
         
     }

--- a/common/src/main/java/hardcorequesting/common/quests/task/icon/TameMobsTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/icon/TameMobsTask.java
@@ -35,7 +35,7 @@ public class TameMobsTask extends IconLayoutTask<TameMobsTask.Part, TameTaskData
     public static final ResourceLocation ABSTRACT_HORSE = new ResourceLocation("abstracthorse");
     
     public TameMobsTask(Quest parent) {
-        super(TaskType.TAME, TameTaskData.class, EditType.Type.MONSTER, parent);
+        super(TaskType.TAME.get(), TameTaskData.class, EditType.Type.MONSTER, parent);
         register(EventTrigger.Type.ANIMAL_TAME);
     }
     

--- a/common/src/main/java/hardcorequesting/common/quests/task/icon/VisitLocationTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/icon/VisitLocationTask.java
@@ -100,6 +100,11 @@ public class VisitLocationTask extends IconLayoutTask<VisitLocationTask.Part, Lo
     }
     
     @Override
+    public LocationTaskData loadData(JsonObject json) {
+        return LocationTaskData.construct(json);
+    }
+    
+    @Override
     public void onUpdate(Player player) {
         
     }

--- a/common/src/main/java/hardcorequesting/common/quests/task/icon/VisitLocationTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/icon/VisitLocationTask.java
@@ -33,7 +33,7 @@ public class VisitLocationTask extends IconLayoutTask<VisitLocationTask.Part, Lo
     private int delay = 1;
     
     public VisitLocationTask(Quest parent) {
-        super(TaskType.LOCATION, LocationTaskData.class, EditType.Type.LOCATION, parent);
+        super(TaskType.LOCATION.get(), LocationTaskData.class, EditType.Type.LOCATION, parent);
         
         register(EventTrigger.Type.SERVER, EventTrigger.Type.PLAYER);
     }

--- a/common/src/main/java/hardcorequesting/common/quests/task/item/BreakBlockTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/item/BreakBlockTask.java
@@ -9,7 +9,7 @@ import net.minecraft.world.level.block.state.BlockState;
 
 public class BreakBlockTask extends BlockRequirementTask {
     public BreakBlockTask(Quest parent) {
-        super(TaskType.BLOCK_BREAK, parent);
+        super(TaskType.BLOCK_BREAK.get(), parent);
         
         register(EventTrigger.Type.BLOCK_BROKEN);
     }

--- a/common/src/main/java/hardcorequesting/common/quests/task/item/ConsumeItemQDSTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/item/ConsumeItemQDSTask.java
@@ -6,6 +6,6 @@ import hardcorequesting.common.quests.task.TaskType;
 public class ConsumeItemQDSTask extends ConsumeItemTask {
     
     public ConsumeItemQDSTask(Quest parent) {
-        super(TaskType.CONSUME_QDS, parent);
+        super(TaskType.CONSUME_QDS.get(), parent);
     }
 }

--- a/common/src/main/java/hardcorequesting/common/quests/task/item/ConsumeItemTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/item/ConsumeItemTask.java
@@ -17,7 +17,7 @@ import java.util.UUID;
 public class ConsumeItemTask extends ItemRequirementTask {
     
     public ConsumeItemTask(Quest parent) {
-        this(TaskType.CONSUME, parent);
+        this(TaskType.CONSUME.get(), parent);
     }
     
     protected ConsumeItemTask(TaskType<? extends ConsumeItemTask> type, Quest parent) {

--- a/common/src/main/java/hardcorequesting/common/quests/task/item/CraftingTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/item/CraftingTask.java
@@ -12,7 +12,7 @@ import net.minecraft.world.item.ItemStack;
 public class CraftingTask extends ItemRequirementTask {
     
     public CraftingTask(Quest parent) {
-        super(TaskType.CRAFT, parent);
+        super(TaskType.CRAFT.get(), parent);
         register(EventTrigger.Type.CRAFTING);
     }
     

--- a/common/src/main/java/hardcorequesting/common/quests/task/item/DetectItemTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/item/DetectItemTask.java
@@ -18,7 +18,7 @@ import java.util.UUID;
 public class DetectItemTask extends ItemRequirementTask {
     
     public DetectItemTask(Quest parent) {
-        super(TaskType.DETECT, parent);
+        super(TaskType.DETECT.get(), parent);
         
         register(EventTrigger.Type.CRAFTING, EventTrigger.Type.PICK_UP, EventTrigger.Type.OPEN_BOOK);
     }

--- a/common/src/main/java/hardcorequesting/common/quests/task/item/ItemRequirementTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/item/ItemRequirementTask.java
@@ -133,6 +133,11 @@ public abstract class ItemRequirementTask extends QuestTask<ItemsTaskData> {
     }
     
     @Override
+    public ItemsTaskData loadData(JsonObject json) {
+        return ItemsTaskData.construct(json);
+    }
+    
+    @Override
     public float getCompletedRatio(Team team) {
         ItemsTaskData data = getData(team);
         int done = 0;

--- a/common/src/main/java/hardcorequesting/common/quests/task/item/PlaceBlockTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/item/PlaceBlockTask.java
@@ -11,7 +11,7 @@ import net.minecraft.world.level.Level;
 
 public class PlaceBlockTask extends ItemRequirementTask {
     public PlaceBlockTask(Quest parent) {
-        super(TaskType.BLOCK_PLACE, parent);
+        super(TaskType.BLOCK_PLACE.get(), parent);
         
         register(EventTrigger.Type.ITEM_USED);
     }

--- a/common/src/main/java/hardcorequesting/common/quests/task/reputation/HaveReputationTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/reputation/HaveReputationTask.java
@@ -10,7 +10,7 @@ import net.minecraft.world.entity.player.Player;
 public class HaveReputationTask extends ReputationTask<TaskData> {
     
     public HaveReputationTask(Quest parent) {
-        super(TaskType.REPUTATION, TaskData.class, parent);
+        super(TaskType.REPUTATION.get(), TaskData.class, parent);
         
         register(EventTrigger.Type.OPEN_BOOK, EventTrigger.Type.REPUTATION_CHANGE);
     }

--- a/common/src/main/java/hardcorequesting/common/quests/task/reputation/HaveReputationTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/reputation/HaveReputationTask.java
@@ -1,5 +1,6 @@
 package hardcorequesting.common.quests.task.reputation;
 
+import com.google.gson.JsonObject;
 import hardcorequesting.common.event.EventTrigger;
 import hardcorequesting.common.quests.Quest;
 import hardcorequesting.common.quests.data.TaskData;
@@ -45,6 +46,11 @@ public class HaveReputationTask extends ReputationTask<TaskData> {
     @Override
     public TaskData newQuestData() {
         return new TaskData();
+    }
+    
+    @Override
+    public TaskData loadData(JsonObject json) {
+        return TaskData.construct(json);
     }
     
     @Override

--- a/common/src/main/java/hardcorequesting/common/quests/task/reputation/KillReputationTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/reputation/KillReputationTask.java
@@ -53,6 +53,11 @@ public class KillReputationTask extends ReputationTask<ReputationKillTaskData> {
     }
     
     @Override
+    public ReputationKillTaskData loadData(JsonObject json) {
+        return ReputationKillTaskData.construct(json);
+    }
+    
+    @Override
     public void onUpdate(Player player) {
         
     }

--- a/common/src/main/java/hardcorequesting/common/quests/task/reputation/KillReputationTask.java
+++ b/common/src/main/java/hardcorequesting/common/quests/task/reputation/KillReputationTask.java
@@ -22,7 +22,7 @@ public class KillReputationTask extends ReputationTask<ReputationKillTaskData> {
     private int kills;
     
     public KillReputationTask(Quest parent) {
-        super(TaskType.REPUTATION_KILL, ReputationKillTaskData.class, parent);
+        super(TaskType.REPUTATION_KILL.get(), ReputationKillTaskData.class, parent);
         
         register(EventTrigger.Type.DEATH);
     }

--- a/forge/src/main/java/hardcorequesting/forge/HardcoreQuestingForge.java
+++ b/forge/src/main/java/hardcorequesting/forge/HardcoreQuestingForge.java
@@ -2,6 +2,7 @@ package hardcorequesting.forge;
 
 import com.mojang.brigadier.CommandDispatcher;
 import dev.architectury.fluid.FluidStack;
+import dev.architectury.platform.forge.EventBuses;
 import hardcorequesting.common.HardcoreQuestingCore;
 import hardcorequesting.common.config.HQMConfig;
 import hardcorequesting.common.items.ModItems;
@@ -87,6 +88,7 @@ public class HardcoreQuestingForge implements AbstractPlatform {
     private final DeferredRegister<BlockEntityType<?>> tileEntityType = DeferredRegister.create(ForgeRegistries.BLOCK_ENTITY_TYPES, HardcoreQuestingCore.ID);
     
     public HardcoreQuestingForge() {
+        EventBuses.registerModEventBus(HardcoreQuestingCore.ID, FMLJavaModLoadingContext.get().getModEventBus());
         NetworkingManager.init();
         HardcoreQuestingCore.initialize(this);
     


### PR DESCRIPTION
Adds a registry for quest task types, allowing potential addons to introduce new types of tasks.
Removes the enum for deserializing quest task data to instead let deserialization go through the quest task, allowing potential addons to define their own task data formats for their own task types.
All task types in the registry are automatically available in the gui when adding tasks to quests.
A scroll bar has been added to that gui for the case that there are more types than fit in the gui. The height of the scroll bar does not perfectly fit the button list, but I saw that as a minor problem:
![2023-01-14_18 14 09](https://user-images.githubusercontent.com/5451660/212537761-ff2a6477-6cc5-4baf-85fe-32ddff6628b0.png)
![2023-01-14_18 14 19](https://user-images.githubusercontent.com/5451660/212537768-109cf4b9-9674-4059-b9dc-e70c5082cdfa.png)

Closes #670